### PR TITLE
Add standalone invoice and quote modules with GST and PDF export

### DIFF
--- a/app.js
+++ b/app.js
@@ -1,0 +1,789 @@
+const GST_RATE = 0.1;
+const CURRENCY = 'AUD';
+
+const currencyFormatter = new Intl.NumberFormat('en-AU', {
+  style: 'currency',
+  currency: CURRENCY,
+  minimumFractionDigits: 2,
+});
+
+const formatCurrency = (value) => currencyFormatter.format(Number(value) || 0);
+
+const deepClone = (value) => {
+  if (typeof structuredClone === 'function') {
+    return structuredClone(value);
+  }
+  return JSON.parse(JSON.stringify(value));
+};
+
+class StorageAdapter {
+  constructor(storageKey) {
+    this.storageKey = storageKey;
+    this.memoryStore = {
+      clients: [],
+      invoices: [],
+      quotes: [],
+    };
+    this.supportsLocalStorage = this.#detectSupport();
+  }
+
+  #detectSupport() {
+    if (typeof window === 'undefined' || !('localStorage' in window)) {
+      return false;
+    }
+
+    try {
+      const testKey = `${this.storageKey}-test`;
+      window.localStorage.setItem(testKey, '1');
+      window.localStorage.removeItem(testKey);
+      return true;
+    } catch (error) {
+      console.warn('LocalStorage unavailable, falling back to memory store.', error);
+      return false;
+    }
+  }
+
+  load() {
+    if (this.supportsLocalStorage) {
+      const raw = window.localStorage.getItem(this.storageKey);
+      if (!raw) {
+        return deepClone(this.memoryStore);
+      }
+
+      try {
+        const parsed = JSON.parse(raw);
+        return {
+          clients: Array.isArray(parsed.clients) ? parsed.clients : [],
+          invoices: Array.isArray(parsed.invoices) ? parsed.invoices : [],
+          quotes: Array.isArray(parsed.quotes) ? parsed.quotes : [],
+        };
+      } catch (error) {
+        console.error('Failed to parse stored data. Resetting store.', error);
+        this.save(this.memoryStore);
+        return deepClone(this.memoryStore);
+      }
+    }
+
+    return deepClone(this.memoryStore);
+  }
+
+  save(data) {
+    const safeData = {
+      clients: Array.isArray(data.clients) ? data.clients : [],
+      invoices: Array.isArray(data.invoices) ? data.invoices : [],
+      quotes: Array.isArray(data.quotes) ? data.quotes : [],
+    };
+
+    if (this.supportsLocalStorage) {
+      window.localStorage.setItem(this.storageKey, JSON.stringify(safeData));
+      return;
+    }
+
+    this.memoryStore = deepClone(safeData);
+  }
+}
+
+class DataManager {
+  constructor(storageKey = 'zantra-invoicing') {
+    this.storage = new StorageAdapter(storageKey);
+    this.data = this.storage.load();
+  }
+
+  #persist() {
+    this.storage.save(this.data);
+  }
+
+  #generateId(prefix) {
+    const fallback = `${prefix}-${Date.now()}-${Math.random().toString(16).slice(2, 8)}`;
+    if (typeof crypto !== 'undefined' && typeof crypto.randomUUID === 'function') {
+      return `${prefix}-${crypto.randomUUID()}`;
+    }
+    return fallback;
+  }
+
+  getClients() {
+    return deepClone(this.data.clients);
+  }
+
+  addClient(client) {
+    const trimmedName = client.name?.trim();
+    if (!trimmedName) {
+      throw new Error('Client name is required.');
+    }
+
+    const normalizedEmail = client.email?.trim();
+    if (normalizedEmail && !/^\S+@\S+\.\S+$/.test(normalizedEmail)) {
+      throw new Error('Client email is invalid.');
+    }
+
+    const newClient = {
+      id: this.#generateId('client'),
+      name: trimmedName,
+      email: normalizedEmail || null,
+      phone: client.phone?.trim() || null,
+      address: client.address?.trim() || null,
+      createdAt: new Date().toISOString(),
+    };
+
+    this.data.clients.push(newClient);
+    this.#persist();
+    return deepClone(newClient);
+  }
+
+  getClientById(id) {
+    return deepClone(this.data.clients.find((client) => client.id === id) || null);
+  }
+
+  getInvoices() {
+    return deepClone(this.data.invoices);
+  }
+
+  saveInvoice(invoice) {
+    const payload = {
+      ...invoice,
+      id: invoice.id || this.#generateId('invoice'),
+      savedAt: new Date().toISOString(),
+    };
+
+    const existingIndex = this.data.invoices.findIndex((item) => item.id === payload.id);
+    if (existingIndex > -1) {
+      this.data.invoices.splice(existingIndex, 1, payload);
+    } else {
+      this.data.invoices.push(payload);
+    }
+
+    this.#persist();
+    return deepClone(payload);
+  }
+
+  getQuotes() {
+    return deepClone(this.data.quotes);
+  }
+
+  saveQuote(quote) {
+    const payload = {
+      ...quote,
+      id: quote.id || this.#generateId('quote'),
+      savedAt: new Date().toISOString(),
+    };
+
+    const existingIndex = this.data.quotes.findIndex((item) => item.id === payload.id);
+    if (existingIndex > -1) {
+      this.data.quotes.splice(existingIndex, 1, payload);
+    } else {
+      this.data.quotes.push(payload);
+    }
+
+    this.#persist();
+    return deepClone(payload);
+  }
+}
+
+const dataManager = new DataManager();
+
+const clientSelects = {
+  invoice: document.getElementById('invoice-client-select'),
+  quote: document.getElementById('quote-client-select'),
+};
+
+const clientDetailBlocks = {
+  invoice: document.getElementById('invoice-client-details'),
+  quote: document.getElementById('quote-client-details'),
+};
+
+const loadClients = () => {
+  const clients = dataManager.getClients();
+  Object.entries(clientSelects).forEach(([key, select]) => {
+    if (!select) return;
+    const currentValue = select.value;
+    select.innerHTML = '<option value="">Select client</option>';
+    clients.forEach((client) => {
+      const option = document.createElement('option');
+      option.value = client.id;
+      option.textContent = client.name;
+      select.append(option);
+    });
+    if (clients.some((client) => client.id === currentValue)) {
+      select.value = currentValue;
+    }
+    renderClientDetails(key, select.value);
+  });
+};
+
+const renderClientDetails = (moduleKey, clientId) => {
+  const target = clientDetailBlocks[moduleKey];
+  if (!target) return;
+
+  if (!clientId) {
+    target.textContent = 'Select a client to link contact details.';
+    target.hidden = false;
+    return;
+  }
+
+  const client = dataManager.getClientById(clientId);
+  if (!client) {
+    target.textContent = 'Client not found.';
+    target.hidden = false;
+    return;
+  }
+
+  const details = [client.name];
+  if (client.email) details.push(`Email: ${client.email}`);
+  if (client.phone) details.push(`Phone: ${client.phone}`);
+  if (client.address) details.push(`Address: ${client.address}`);
+  target.textContent = details.join('\n');
+  target.hidden = false;
+};
+
+const setupClientForms = () => {
+  const configs = [
+    {
+      addButtonId: 'invoice-add-client',
+      formId: 'invoice-client-form',
+      fields: {
+        name: 'invoice-client-name',
+        email: 'invoice-client-email',
+        phone: 'invoice-client-phone',
+        address: 'invoice-client-address',
+      },
+      saveButtonId: 'invoice-save-client',
+      cancelButtonId: 'invoice-cancel-client',
+      selectKey: 'invoice',
+    },
+    {
+      addButtonId: 'quote-add-client',
+      formId: 'quote-client-form',
+      fields: {
+        name: 'quote-client-name',
+        email: 'quote-client-email',
+        phone: 'quote-client-phone',
+        address: 'quote-client-address',
+      },
+      saveButtonId: 'quote-save-client',
+      cancelButtonId: 'quote-cancel-client',
+      selectKey: 'quote',
+    },
+  ];
+
+  configs.forEach((config) => {
+    const addButton = document.getElementById(config.addButtonId);
+    const form = document.getElementById(config.formId);
+    const saveButton = document.getElementById(config.saveButtonId);
+    const cancelButton = document.getElementById(config.cancelButtonId);
+
+    const showForm = () => {
+      form.hidden = false;
+      form.scrollIntoView({ behavior: 'smooth', block: 'center' });
+    };
+
+    const hideForm = () => {
+      form.hidden = true;
+      Object.values(config.fields).forEach((fieldId) => {
+        const field = document.getElementById(fieldId);
+        if (field) field.value = '';
+      });
+    };
+
+    addButton?.addEventListener('click', () => {
+      showForm();
+    });
+
+    cancelButton?.addEventListener('click', () => {
+      hideForm();
+    });
+
+    saveButton?.addEventListener('click', () => {
+      try {
+        const clientPayload = Object.fromEntries(
+          Object.entries(config.fields).map(([key, fieldId]) => {
+            const field = document.getElementById(fieldId);
+            return [key, field?.value ?? ''];
+          })
+        );
+
+        const savedClient = dataManager.addClient(clientPayload);
+        hideForm();
+        loadClients();
+        const select = clientSelects[config.selectKey];
+        if (select) {
+          select.value = savedClient.id;
+          renderClientDetails(config.selectKey, savedClient.id);
+        }
+      } catch (error) {
+        window.alert(error.message);
+      }
+    });
+  });
+};
+
+const createLineItemRow = () => {
+  const template = document.getElementById('line-item-template');
+  if (!template?.content) {
+    throw new Error('Missing line item template.');
+  }
+  return template.content.firstElementChild.cloneNode(true);
+};
+
+const calculateTotals = (tbody) => {
+  const rows = Array.from(tbody.querySelectorAll('tr'));
+  let subtotal = 0;
+  let gst = 0;
+
+  rows.forEach((row) => {
+    const quantityField = row.querySelector('.line-quantity');
+    const priceField = row.querySelector('.line-price');
+    const gstField = row.querySelector('.line-gst');
+    const lineTotalCell = row.querySelector('.line-total');
+
+    const quantity = Math.max(Number.parseFloat(quantityField?.value ?? '0') || 0, 0);
+    const unitPrice = Math.max(Number.parseFloat(priceField?.value ?? '0') || 0, 0);
+    const applyGst = Boolean(gstField?.checked);
+
+    const net = quantity * unitPrice;
+    const gstAmount = applyGst ? net * GST_RATE : 0;
+    const gross = net + gstAmount;
+
+    subtotal += net;
+    gst += gstAmount;
+
+    if (lineTotalCell) {
+      lineTotalCell.textContent = formatCurrency(gross);
+    }
+  });
+
+  return { subtotal, gst, total: subtotal + gst };
+};
+
+const registerLineItemEvents = (row, onChange) => {
+  const quantityField = row.querySelector('.line-quantity');
+  const priceField = row.querySelector('.line-price');
+  const gstField = row.querySelector('.line-gst');
+  const removeButton = row.querySelector('.remove-item');
+
+  [quantityField, priceField].forEach((field) => {
+    field?.addEventListener('input', onChange);
+  });
+  gstField?.addEventListener('change', onChange);
+  removeButton?.addEventListener('click', () => {
+    row.remove();
+    onChange();
+  });
+};
+
+const ensureLineItem = (tbody, onChange) => {
+  if (tbody.children.length === 0) {
+    const row = createLineItemRow();
+    tbody.append(row);
+    registerLineItemEvents(row, onChange);
+    onChange();
+  }
+};
+
+const updateTotalsUI = (subtotalEl, gstEl, totalEl, totals) => {
+  if (subtotalEl) subtotalEl.textContent = formatCurrency(totals.subtotal);
+  if (gstEl) gstEl.textContent = formatCurrency(totals.gst);
+  if (totalEl) totalEl.textContent = formatCurrency(totals.total);
+};
+
+const mapRowsToLineItems = (tbody) =>
+  Array.from(tbody.querySelectorAll('tr')).map((row) => {
+    const quantity = Math.max(Number.parseFloat(row.querySelector('.line-quantity')?.value ?? '0') || 0, 0);
+    const unitPrice = Math.max(Number.parseFloat(row.querySelector('.line-price')?.value ?? '0') || 0, 0);
+    const applyGst = Boolean(row.querySelector('.line-gst')?.checked);
+    const net = quantity * unitPrice;
+    const gst = applyGst ? net * GST_RATE : 0;
+
+    return {
+      description: row.querySelector('.line-description')?.value?.trim() || 'Untitled item',
+      quantity,
+      unitPrice,
+      applyGst,
+      net,
+      gst,
+      total: net + gst,
+    };
+  });
+
+const calculateDueDate = (baseDate, terms) => {
+  if (!baseDate) return '';
+  const currentDate = new Date(baseDate);
+  if (Number.isNaN(currentDate.getTime())) return '';
+
+  if (terms === 'on_receipt') {
+    return currentDate.toISOString().slice(0, 10);
+  }
+
+  const days = Number.parseInt(terms, 10);
+  if (Number.isFinite(days)) {
+    currentDate.setDate(currentDate.getDate() + days);
+    return currentDate.toISOString().slice(0, 10);
+  }
+
+  return '';
+};
+
+const setupDateAutomation = (config) => {
+  const baseField = document.getElementById(config.baseFieldId);
+  const termsField = document.getElementById(config.termsFieldId);
+  const targetField = document.getElementById(config.targetFieldId);
+
+  const update = () => {
+    if (!baseField || !termsField || !targetField) return;
+    const termsValue = termsField.value;
+    if (termsValue === 'custom') {
+      targetField.removeAttribute('readonly');
+      return;
+    }
+
+    targetField.setAttribute('readonly', 'true');
+    const calculated = calculateDueDate(baseField.value, termsValue);
+    targetField.value = calculated;
+  };
+
+  baseField?.addEventListener('change', update);
+  termsField?.addEventListener('change', update);
+  update();
+};
+
+const renderRecords = (listElement, records, type) => {
+  if (!listElement) return;
+  listElement.innerHTML = '';
+
+  if (!records.length) {
+    const empty = document.createElement('li');
+    empty.className = 'record';
+    empty.textContent = `No ${type} saved yet.`;
+    listElement.append(empty);
+    return;
+  }
+
+  const clients = dataManager.getClients().reduce((acc, client) => {
+    acc[client.id] = client;
+    return acc;
+  }, {});
+
+  records
+    .sort((a, b) => new Date(b.savedAt).getTime() - new Date(a.savedAt).getTime())
+    .forEach((record) => {
+      const item = document.createElement('li');
+      item.className = 'record';
+      const client = clients[record.clientId];
+      const title = document.createElement('strong');
+      title.textContent = `${type === 'invoice' ? 'Invoice' : 'Quote'} ${record.number}`;
+
+      const clientLine = document.createElement('span');
+      clientLine.textContent = client
+        ? `Client: ${client.name}`
+        : 'Client: Unlinked';
+
+      const totalLine = document.createElement('span');
+      totalLine.textContent = `Total: ${formatCurrency(record.totals?.total ?? 0)}`;
+
+      const dateLine = document.createElement('span');
+      dateLine.textContent = type === 'invoice'
+        ? `Due: ${record.dueDate || 'N/A'}`
+        : `Valid until: ${record.expiryDate || 'N/A'}`;
+
+      item.append(title, clientLine, totalLine, dateLine);
+      listElement.append(item);
+    });
+};
+
+const exportToPdf = async (config, data) => {
+  if (!window.jspdf || !window.jspdf.jsPDF) {
+    window.alert('jsPDF failed to load. Please check your connection.');
+    return;
+  }
+
+  const doc = new window.jspdf.jsPDF({ unit: 'pt', format: 'a4' });
+  const margin = 40;
+  const lineHeight = 18;
+  let y = margin;
+
+  const addLine = (text, options = {}) => {
+    doc.text(text, margin, y, options);
+    y += lineHeight;
+  };
+
+  doc.setFont('helvetica', 'bold');
+  doc.setFontSize(20);
+  addLine(config.title, { align: 'left' });
+
+  doc.setFontSize(12);
+  doc.setFont('helvetica', 'normal');
+  addLine(`${config.numberLabel}: ${data.number}`);
+  addLine(`Date: ${data.issueDate || data.quoteDate}`);
+  if (config.dueLabel && data.dueDate) {
+    addLine(`${config.dueLabel}: ${data.dueDate}`);
+  }
+  if (config.expiryLabel && data.expiryDate) {
+    addLine(`${config.expiryLabel}: ${data.expiryDate}`);
+  }
+
+  y += lineHeight;
+  const client = dataManager.getClientById(data.clientId);
+  addLine('Bill To:', { align: 'left' });
+  if (client) {
+    addLine(client.name);
+    if (client.email) addLine(client.email);
+    if (client.phone) addLine(client.phone);
+    if (client.address) {
+      client.address.split(/\r?\n/).forEach((line) => addLine(line));
+    }
+  } else {
+    addLine('Unlinked client');
+  }
+
+  y += lineHeight;
+
+  doc.setFont('helvetica', 'bold');
+  addLine('Items:');
+  doc.setFont('helvetica', 'normal');
+
+  data.lineItems.forEach((item, index) => {
+    addLine(`${index + 1}. ${item.description}`);
+    addLine(`   Qty: ${item.quantity} @ ${formatCurrency(item.unitPrice)} (${item.applyGst ? 'GST' : 'No GST'})`);
+    addLine(`   Line total: ${formatCurrency(item.total)}`);
+  });
+
+  y += lineHeight;
+  doc.setFont('helvetica', 'bold');
+  addLine(`Subtotal: ${formatCurrency(data.totals.subtotal)}`);
+  addLine(`GST: ${formatCurrency(data.totals.gst)}`);
+  addLine(`Total: ${formatCurrency(data.totals.total)}`);
+
+  const fileName = `${config.filePrefix}-${data.number || 'document'}.pdf`.replace(/\s+/g, '-');
+  doc.save(fileName);
+};
+
+const setupModule = (moduleConfig) => {
+  const form = document.getElementById(moduleConfig.formId);
+  const addItemButton = document.getElementById(moduleConfig.addItemButtonId);
+  const itemsTbody = document.getElementById(moduleConfig.itemsTbodyId);
+  const subtotalEl = document.getElementById(moduleConfig.subtotalId);
+  const gstEl = document.getElementById(moduleConfig.gstId);
+  const totalEl = document.getElementById(moduleConfig.totalId);
+  const exportButton = document.getElementById(moduleConfig.exportButtonId);
+  const listElement = document.getElementById(moduleConfig.listId);
+
+  const recalculate = () => {
+    if (!itemsTbody) return;
+    const totals = calculateTotals(itemsTbody);
+    updateTotalsUI(subtotalEl, gstEl, totalEl, totals);
+    return totals;
+  };
+
+  ensureLineItem(itemsTbody, recalculate);
+
+  addItemButton?.addEventListener('click', () => {
+    const row = createLineItemRow();
+    itemsTbody.append(row);
+    registerLineItemEvents(row, recalculate);
+    recalculate();
+  });
+
+  Array.from(itemsTbody?.querySelectorAll('tr') ?? []).forEach((row) =>
+    registerLineItemEvents(row, recalculate)
+  );
+
+  form?.addEventListener('submit', (event) => {
+    event.preventDefault();
+
+    const numberField = document.getElementById(moduleConfig.numberFieldId);
+    const dateField = document.getElementById(moduleConfig.dateFieldId);
+    const targetField = document.getElementById(moduleConfig.targetFieldId);
+    const clientSelect = clientSelects[moduleConfig.type];
+
+    if (!numberField?.value.trim()) {
+      numberField?.focus();
+      numberField?.setCustomValidity('This field is required.');
+      numberField?.reportValidity();
+      numberField?.addEventListener('input', () => numberField.setCustomValidity(''), {
+        once: true,
+      });
+      return;
+    }
+
+    if (!dateField?.value) {
+      dateField?.focus();
+      dateField?.setCustomValidity('Please select a date.');
+      dateField?.reportValidity();
+      dateField?.addEventListener('change', () => dateField.setCustomValidity(''), {
+        once: true,
+      });
+      return;
+    }
+
+    if (!clientSelect?.value) {
+      clientSelect?.focus();
+      clientSelect?.setCustomValidity('Please link a client.');
+      clientSelect?.reportValidity();
+      clientSelect?.addEventListener('change', () => clientSelect.setCustomValidity(''), {
+        once: true,
+      });
+      return;
+    }
+
+    const lineItems = mapRowsToLineItems(itemsTbody);
+    if (!lineItems.length) {
+      window.alert('Please add at least one line item.');
+      return;
+    }
+
+    const totals = recalculate();
+    const payload = {
+      number: numberField.value.trim(),
+      clientId: clientSelect.value,
+      lineItems,
+      totals,
+      notes: null,
+    };
+
+    if (moduleConfig.type === 'invoice') {
+      Object.assign(payload, {
+        issueDate: dateField.value,
+        dueDate: targetField?.value || '',
+        dueTerms: document.getElementById(moduleConfig.termsFieldId)?.value || 'on_receipt',
+      });
+      const saved = dataManager.saveInvoice(payload);
+      window.alert(`Invoice ${saved.number} saved.`);
+    } else {
+      Object.assign(payload, {
+        quoteDate: dateField.value,
+        expiryDate: targetField?.value || '',
+        validityTerms: document.getElementById(moduleConfig.termsFieldId)?.value || '14',
+      });
+      const saved = dataManager.saveQuote(payload);
+      window.alert(`Quote ${saved.number} saved.`);
+    }
+
+    renderRecords(
+      listElement,
+      moduleConfig.type === 'invoice' ? dataManager.getInvoices() : dataManager.getQuotes(),
+      moduleConfig.type
+    );
+  });
+
+  exportButton?.addEventListener('click', () => {
+    const numberField = document.getElementById(moduleConfig.numberFieldId);
+    const dateField = document.getElementById(moduleConfig.dateFieldId);
+    const targetField = document.getElementById(moduleConfig.targetFieldId);
+    const clientSelect = clientSelects[moduleConfig.type];
+    const totals = recalculate();
+    const data = {
+      number: numberField?.value.trim() || '',
+      clientId: clientSelect?.value || '',
+      lineItems: mapRowsToLineItems(itemsTbody),
+      totals,
+    };
+
+    if (moduleConfig.type === 'invoice') {
+      Object.assign(data, {
+        issueDate: dateField?.value || '',
+        dueDate: targetField?.value || '',
+      });
+    } else {
+      Object.assign(data, {
+        quoteDate: dateField?.value || '',
+        expiryDate: targetField?.value || '',
+      });
+    }
+
+    exportToPdf(moduleConfig.pdfConfig, data);
+  });
+
+  renderRecords(
+    listElement,
+    moduleConfig.type === 'invoice' ? dataManager.getInvoices() : dataManager.getQuotes(),
+    moduleConfig.type
+  );
+};
+
+const setupTabs = () => {
+  const buttons = Array.from(document.querySelectorAll('.tab-button'));
+  const panels = Array.from(document.querySelectorAll('.tab-panel'));
+
+  buttons.forEach((button) => {
+    button.addEventListener('click', () => {
+      const targetId = button.dataset.target;
+      buttons.forEach((btn) => {
+        const isActive = btn === button;
+        btn.classList.toggle('is-active', isActive);
+        btn.setAttribute('aria-selected', String(isActive));
+      });
+      panels.forEach((panel) => {
+        const shouldShow = panel.id === targetId;
+        panel.classList.toggle('is-hidden', !shouldShow);
+        panel.toggleAttribute('hidden', !shouldShow);
+      });
+    });
+  });
+};
+
+document.addEventListener('DOMContentLoaded', () => {
+  setupTabs();
+  loadClients();
+  setupClientForms();
+
+  setupDateAutomation({
+    baseFieldId: 'invoice-issue-date',
+    termsFieldId: 'invoice-due-terms',
+    targetFieldId: 'invoice-due-date',
+  });
+
+  setupDateAutomation({
+    baseFieldId: 'quote-date',
+    termsFieldId: 'quote-valid-terms',
+    targetFieldId: 'quote-valid-date',
+  });
+
+  setupModule({
+    type: 'invoice',
+    formId: 'invoice-form',
+    addItemButtonId: 'invoice-add-item',
+    itemsTbodyId: 'invoice-items',
+    subtotalId: 'invoice-subtotal',
+    gstId: 'invoice-gst',
+    totalId: 'invoice-total',
+    exportButtonId: 'invoice-export',
+    listId: 'invoice-list',
+    numberFieldId: 'invoice-number',
+    dateFieldId: 'invoice-issue-date',
+    targetFieldId: 'invoice-due-date',
+    termsFieldId: 'invoice-due-terms',
+    pdfConfig: {
+      title: 'Invoice',
+      numberLabel: 'Invoice Number',
+      dueLabel: 'Due Date',
+      filePrefix: 'invoice',
+    },
+  });
+
+  setupModule({
+    type: 'quote',
+    formId: 'quote-form',
+    addItemButtonId: 'quote-add-item',
+    itemsTbodyId: 'quote-items',
+    subtotalId: 'quote-subtotal',
+    gstId: 'quote-gst',
+    totalId: 'quote-total',
+    exportButtonId: 'quote-export',
+    listId: 'quote-list',
+    numberFieldId: 'quote-number',
+    dateFieldId: 'quote-date',
+    targetFieldId: 'quote-valid-date',
+    termsFieldId: 'quote-valid-terms',
+    pdfConfig: {
+      title: 'Quote',
+      numberLabel: 'Quote Number',
+      expiryLabel: 'Valid Until',
+      filePrefix: 'quote',
+    },
+  });
+
+  Object.entries(clientSelects).forEach(([key, select]) => {
+    select?.addEventListener('change', (event) => {
+      renderClientDetails(key, event.target.value);
+    });
+  });
+});

--- a/index.html
+++ b/index.html
@@ -1,0 +1,336 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Zantra Invoicing</title>
+    <link rel="stylesheet" href="styles.css" />
+    <link
+      rel="preconnect"
+      href="https://fonts.googleapis.com"
+    />
+    <link
+      rel="preconnect"
+      href="https://fonts.gstatic.com"
+      crossorigin
+    />
+    <link
+      href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap"
+      rel="stylesheet"
+    />
+    <script
+      src="https://cdnjs.cloudflare.com/ajax/libs/jspdf/2.5.1/jspdf.umd.min.js"
+      integrity="sha512-3gJwYpH9sC7FQLmN0pX69teZUR0vbJIUKGwEuITdSb9VInA36TObgGJE0E7E5Wdl66iRS0LlwM651c01rbFG2g=="
+      crossorigin="anonymous"
+      referrerpolicy="no-referrer"
+      defer
+    ></script>
+    <script src="app.js" type="module" defer></script>
+  </head>
+  <body>
+    <header class="app-header">
+      <h1>Zantra Invoicing Suite</h1>
+      <p>Generate invoices and quotes with GST support and client management.</p>
+    </header>
+
+    <main class="app-main">
+      <nav class="tab-nav" aria-label="Primary">
+        <button
+          class="tab-button is-active"
+          type="button"
+          data-target="invoice-module"
+          aria-controls="invoice-module"
+          aria-selected="true"
+          role="tab"
+        >
+          Invoice Module
+        </button>
+        <button
+          class="tab-button"
+          type="button"
+          data-target="quote-module"
+          aria-controls="quote-module"
+          aria-selected="false"
+          role="tab"
+        >
+          Quote Module
+        </button>
+      </nav>
+
+      <section
+        id="invoice-module"
+        class="tab-panel"
+        role="tabpanel"
+        aria-labelledby="invoice-module"
+      >
+        <h2>Invoice Builder</h2>
+        <form id="invoice-form" novalidate>
+          <div class="grid">
+            <label class="field">
+              <span>Invoice Number</span>
+              <input type="text" id="invoice-number" required aria-required="true" />
+            </label>
+            <label class="field">
+              <span>Issue Date</span>
+              <input type="date" id="invoice-issue-date" required aria-required="true" />
+            </label>
+            <label class="field">
+              <span>Due Terms</span>
+              <select id="invoice-due-terms" aria-label="Invoice due date terms">
+                <option value="on_receipt">On Receipt</option>
+                <option value="7">7 Days</option>
+                <option value="14">14 Days</option>
+                <option value="30">30 Days</option>
+                <option value="custom">Custom</option>
+              </select>
+            </label>
+            <label class="field" id="invoice-due-date-wrapper">
+              <span>Due Date</span>
+              <input type="date" id="invoice-due-date" aria-describedby="invoice-due-helper" />
+              <small id="invoice-due-helper">Automatically calculated unless custom.</small>
+            </label>
+          </div>
+
+          <div class="field">
+            <span>Client</span>
+            <div class="client-selector">
+              <select id="invoice-client-select" aria-label="Select client for invoice">
+                <option value="">Select client</option>
+              </select>
+              <button type="button" class="secondary" id="invoice-add-client">Add New Client</button>
+            </div>
+            <div
+              class="client-details"
+              id="invoice-client-details"
+              role="note"
+              aria-live="polite"
+            ></div>
+          </div>
+
+          <div class="client-form" id="invoice-client-form" hidden>
+            <h3>New Client</h3>
+            <div class="grid">
+              <label class="field">
+                <span>Company Name</span>
+                <input type="text" id="invoice-client-name" />
+              </label>
+              <label class="field">
+                <span>Contact Email</span>
+                <input type="email" id="invoice-client-email" />
+              </label>
+              <label class="field">
+                <span>Phone</span>
+                <input type="tel" id="invoice-client-phone" />
+              </label>
+              <label class="field">
+                <span>Address</span>
+                <textarea id="invoice-client-address" rows="3"></textarea>
+              </label>
+            </div>
+            <div class="button-row">
+              <button type="button" class="primary" id="invoice-save-client">Save Client</button>
+              <button type="button" class="secondary" id="invoice-cancel-client">Cancel</button>
+            </div>
+          </div>
+
+          <div class="line-items" aria-live="polite">
+            <div class="line-item-header">
+              <h3>Line Items</h3>
+              <button type="button" class="primary" id="invoice-add-item">Add Line Item</button>
+            </div>
+            <div class="table-wrapper">
+              <table>
+                <thead>
+                  <tr>
+                    <th scope="col">Description</th>
+                    <th scope="col">Quantity</th>
+                    <th scope="col">Unit Price</th>
+                    <th scope="col">GST</th>
+                    <th scope="col">Line Total</th>
+                    <th scope="col" class="sr-only">Actions</th>
+                  </tr>
+                </thead>
+                <tbody id="invoice-items"></tbody>
+              </table>
+            </div>
+          </div>
+
+          <aside class="totals" aria-live="polite">
+            <div class="totals-row">
+              <span>Subtotal</span>
+              <span id="invoice-subtotal" data-currency>$0.00</span>
+            </div>
+            <div class="totals-row">
+              <span>GST (10%)</span>
+              <span id="invoice-gst" data-currency>$0.00</span>
+            </div>
+            <div class="totals-row grand-total">
+              <span>Total Due</span>
+              <span id="invoice-total" data-currency>$0.00</span>
+            </div>
+          </aside>
+
+          <div class="button-row">
+            <button type="submit" class="primary">Save Invoice</button>
+            <button type="button" class="secondary" id="invoice-export">Export PDF</button>
+          </div>
+        </form>
+
+        <section aria-labelledby="invoice-list-heading" class="records">
+          <h3 id="invoice-list-heading">Saved Invoices</h3>
+          <ul id="invoice-list" class="record-list" aria-live="polite"></ul>
+        </section>
+      </section>
+
+      <section
+        id="quote-module"
+        class="tab-panel is-hidden"
+        role="tabpanel"
+        aria-labelledby="quote-module"
+        hidden
+      >
+        <h2>Quote Builder</h2>
+        <form id="quote-form" novalidate>
+          <div class="grid">
+            <label class="field">
+              <span>Quote Number</span>
+              <input type="text" id="quote-number" required aria-required="true" />
+            </label>
+            <label class="field">
+              <span>Quote Date</span>
+              <input type="date" id="quote-date" required aria-required="true" />
+            </label>
+            <label class="field">
+              <span>Valid Until</span>
+              <select id="quote-valid-terms" aria-label="Quote validity terms">
+                <option value="7">7 Days</option>
+                <option value="14">14 Days</option>
+                <option value="30">30 Days</option>
+                <option value="custom">Custom</option>
+              </select>
+            </label>
+            <label class="field" id="quote-valid-date-wrapper">
+              <span>Expiry Date</span>
+              <input type="date" id="quote-valid-date" aria-describedby="quote-valid-helper" />
+              <small id="quote-valid-helper">Automatically calculated unless custom.</small>
+            </label>
+          </div>
+
+          <div class="field">
+            <span>Client</span>
+            <div class="client-selector">
+              <select id="quote-client-select" aria-label="Select client for quote">
+                <option value="">Select client</option>
+              </select>
+              <button type="button" class="secondary" id="quote-add-client">Add New Client</button>
+            </div>
+            <div
+              class="client-details"
+              id="quote-client-details"
+              role="note"
+              aria-live="polite"
+            ></div>
+          </div>
+
+          <div class="client-form" id="quote-client-form" hidden>
+            <h3>New Client</h3>
+            <div class="grid">
+              <label class="field">
+                <span>Company Name</span>
+                <input type="text" id="quote-client-name" />
+              </label>
+              <label class="field">
+                <span>Contact Email</span>
+                <input type="email" id="quote-client-email" />
+              </label>
+              <label class="field">
+                <span>Phone</span>
+                <input type="tel" id="quote-client-phone" />
+              </label>
+              <label class="field">
+                <span>Address</span>
+                <textarea id="quote-client-address" rows="3"></textarea>
+              </label>
+            </div>
+            <div class="button-row">
+              <button type="button" class="primary" id="quote-save-client">Save Client</button>
+              <button type="button" class="secondary" id="quote-cancel-client">Cancel</button>
+            </div>
+          </div>
+
+          <div class="line-items" aria-live="polite">
+            <div class="line-item-header">
+              <h3>Line Items</h3>
+              <button type="button" class="primary" id="quote-add-item">Add Line Item</button>
+            </div>
+            <div class="table-wrapper">
+              <table>
+                <thead>
+                  <tr>
+                    <th scope="col">Description</th>
+                    <th scope="col">Quantity</th>
+                    <th scope="col">Unit Price</th>
+                    <th scope="col">GST</th>
+                    <th scope="col">Line Total</th>
+                    <th scope="col" class="sr-only">Actions</th>
+                  </tr>
+                </thead>
+                <tbody id="quote-items"></tbody>
+              </table>
+            </div>
+          </div>
+
+          <aside class="totals" aria-live="polite">
+            <div class="totals-row">
+              <span>Subtotal</span>
+              <span id="quote-subtotal" data-currency>$0.00</span>
+            </div>
+            <div class="totals-row">
+              <span>GST (10%)</span>
+              <span id="quote-gst" data-currency>$0.00</span>
+            </div>
+            <div class="totals-row grand-total">
+              <span>Total</span>
+              <span id="quote-total" data-currency>$0.00</span>
+            </div>
+          </aside>
+
+          <div class="button-row">
+            <button type="submit" class="primary">Save Quote</button>
+            <button type="button" class="secondary" id="quote-export">Export PDF</button>
+          </div>
+        </form>
+
+        <section aria-labelledby="quote-list-heading" class="records">
+          <h3 id="quote-list-heading">Saved Quotes</h3>
+          <ul id="quote-list" class="record-list" aria-live="polite"></ul>
+        </section>
+      </section>
+    </main>
+
+    <template id="line-item-template">
+      <tr>
+        <td data-label="Description">
+          <input type="text" class="line-description" placeholder="Item description" />
+        </td>
+        <td data-label="Quantity">
+          <input type="number" class="line-quantity" min="0" step="1" value="1" />
+        </td>
+        <td data-label="Unit Price">
+          <input type="number" class="line-price" min="0" step="0.01" value="0.00" />
+        </td>
+        <td data-label="GST">
+          <label class="switch">
+            <input type="checkbox" class="line-gst" checked />
+            <span class="slider" aria-hidden="true"></span>
+            <span class="sr-only">Apply GST</span>
+          </label>
+        </td>
+        <td data-label="Line Total" class="line-total" data-currency>$0.00</td>
+        <td data-label="Actions">
+          <button type="button" class="icon-button remove-item" aria-label="Remove line item">&times;</button>
+        </td>
+      </tr>
+    </template>
+  </body>
+</html>

--- a/styles.css
+++ b/styles.css
@@ -1,0 +1,445 @@
+:root {
+  color-scheme: light dark;
+  font-family: 'Inter', system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI',
+    sans-serif;
+  line-height: 1.5;
+  font-weight: 400;
+  --surface: #ffffff;
+  --surface-muted: #f5f5f5;
+  --text: #1f2933;
+  --accent: #2563eb;
+  --accent-dark: #1d4ed8;
+  --border: #d1d5db;
+  --border-strong: #94a3b8;
+  --shadow: rgba(15, 23, 42, 0.1);
+}
+
+@media (prefers-color-scheme: dark) {
+  :root {
+    --surface: #0f172a;
+    --surface-muted: #111c38;
+    --text: #e2e8f0;
+    --accent: #60a5fa;
+    --accent-dark: #3b82f6;
+    --border: #1e293b;
+    --border-strong: #334155;
+    --shadow: rgba(15, 23, 42, 0.4);
+  }
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  background: var(--surface-muted);
+  color: var(--text);
+  min-height: 100vh;
+}
+
+h1,
+ h2,
+ h3 {
+  line-height: 1.2;
+  margin: 0 0 0.5rem;
+  color: var(--text);
+}
+
+p {
+  margin: 0;
+}
+
+.app-header {
+  padding: 2rem clamp(1rem, 5vw, 3rem);
+  background: var(--surface);
+  box-shadow: 0 2px 12px var(--shadow);
+  position: sticky;
+  top: 0;
+  z-index: 1;
+}
+
+.app-header h1 {
+  font-size: clamp(1.5rem, 2.8vw, 2.4rem);
+}
+
+.app-header p {
+  max-width: 640px;
+  margin-top: 0.5rem;
+  color: color-mix(in srgb, var(--text) 70%, transparent);
+}
+
+.app-main {
+  padding: 2rem clamp(1rem, 5vw, 3rem) 4rem;
+  display: grid;
+  gap: 2rem;
+}
+
+.tab-nav {
+  display: inline-flex;
+  gap: 0.5rem;
+  background: var(--surface);
+  padding: 0.5rem;
+  border-radius: 999px;
+  box-shadow: 0 4px 16px var(--shadow);
+}
+
+.tab-button {
+  border: none;
+  background: transparent;
+  padding: 0.75rem 1.5rem;
+  border-radius: 999px;
+  font-weight: 600;
+  color: color-mix(in srgb, var(--text) 65%, transparent);
+  cursor: pointer;
+  transition: background 150ms ease, color 150ms ease, transform 150ms ease;
+}
+
+.tab-button:focus-visible {
+  outline: 3px solid color-mix(in srgb, var(--accent) 60%, white);
+  outline-offset: 3px;
+}
+
+.tab-button:hover {
+  color: var(--text);
+}
+
+.tab-button.is-active {
+  background: var(--accent);
+  color: white;
+  box-shadow: 0 6px 20px color-mix(in srgb, var(--accent) 30%, black 0%);
+}
+
+.tab-panel {
+  background: var(--surface);
+  border-radius: 20px;
+  padding: clamp(1.5rem, 3vw, 2.5rem);
+  box-shadow: 0 12px 32px var(--shadow);
+}
+
+.tab-panel.is-hidden {
+  display: none;
+}
+
+form {
+  display: grid;
+  gap: 1.5rem;
+}
+
+.grid {
+  display: grid;
+  gap: 1rem;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+}
+
+.field {
+  display: grid;
+  gap: 0.4rem;
+  font-size: 0.95rem;
+}
+
+.field span {
+  font-weight: 600;
+}
+
+.field input,
+.field textarea,
+.field select {
+  border: 1px solid var(--border);
+  border-radius: 10px;
+  padding: 0.6rem 0.8rem;
+  font: inherit;
+  background: var(--surface-muted);
+  color: var(--text);
+  transition: border 150ms ease, box-shadow 150ms ease;
+}
+
+.field input:focus-visible,
+.field textarea:focus-visible,
+.field select:focus-visible {
+  outline: none;
+  border-color: var(--accent);
+  box-shadow: 0 0 0 3px color-mix(in srgb, var(--accent) 25%, transparent);
+}
+
+.client-selector {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.75rem;
+  align-items: center;
+}
+
+.client-selector select {
+  flex: 1 1 240px;
+}
+
+.client-details {
+  margin-top: 0.5rem;
+  padding: 0.75rem 1rem;
+  border-radius: 10px;
+  background: color-mix(in srgb, var(--surface) 94%, var(--accent) 6%);
+  color: color-mix(in srgb, var(--text) 85%, transparent);
+  white-space: pre-line;
+  border: 1px solid color-mix(in srgb, var(--border) 80%, var(--accent) 20%);
+}
+
+.client-form {
+  padding: 1.5rem;
+  border-radius: 14px;
+  background: color-mix(in srgb, var(--surface) 92%, var(--accent) 8%);
+  border: 1px dashed var(--border-strong);
+}
+
+.button-row {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.75rem;
+}
+
+button {
+  font: inherit;
+  border-radius: 999px;
+  border: none;
+  padding: 0.65rem 1.4rem;
+  cursor: pointer;
+  transition: transform 150ms ease, box-shadow 150ms ease, background 150ms ease;
+}
+
+button:disabled {
+  cursor: not-allowed;
+  opacity: 0.6;
+}
+
+button.primary {
+  background: var(--accent);
+  color: white;
+  box-shadow: 0 6px 18px color-mix(in srgb, var(--accent) 25%, black 0%);
+}
+
+button.primary:hover {
+  background: var(--accent-dark);
+  transform: translateY(-1px);
+}
+
+button.secondary {
+  background: transparent;
+  border: 1px solid var(--border-strong);
+  color: var(--text);
+}
+
+button.secondary:hover {
+  background: var(--surface-muted);
+}
+
+.icon-button {
+  background: transparent;
+  border: none;
+  font-size: 1.5rem;
+  padding: 0.25rem;
+  color: var(--accent);
+}
+
+.icon-button:hover {
+  color: var(--accent-dark);
+}
+
+.line-items {
+  display: grid;
+  gap: 1rem;
+}
+
+.line-item-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+}
+
+.table-wrapper {
+  overflow-x: auto;
+}
+
+table {
+  width: 100%;
+  border-collapse: collapse;
+  min-width: 640px;
+}
+
+thead {
+  background: var(--surface-muted);
+}
+
+thead th {
+  text-align: left;
+  padding: 0.75rem;
+  font-size: 0.85rem;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+}
+
+tbody td {
+  padding: 0.75rem;
+  border-bottom: 1px solid var(--border);
+}
+
+tbody tr:hover {
+  background: color-mix(in srgb, var(--surface-muted) 88%, var(--accent) 12%);
+}
+
+.line-total {
+  font-weight: 600;
+  text-align: right;
+}
+
+.totals {
+  margin-left: auto;
+  min-width: 280px;
+  display: grid;
+  gap: 0.5rem;
+  padding: 1.2rem 1.5rem;
+  background: color-mix(in srgb, var(--surface) 92%, var(--accent) 8%);
+  border-radius: 16px;
+}
+
+.totals-row {
+  display: flex;
+  justify-content: space-between;
+  font-weight: 600;
+}
+
+.totals-row.grand-total {
+  font-size: 1.2rem;
+}
+
+.records {
+  margin-top: 2rem;
+}
+
+.record-list {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+  display: grid;
+  gap: 1rem;
+}
+
+.record {
+  background: var(--surface);
+  border: 1px solid var(--border);
+  border-radius: 14px;
+  padding: 1rem 1.25rem;
+  display: grid;
+  gap: 0.25rem;
+}
+
+.record strong {
+  font-weight: 600;
+}
+
+.sr-only {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  border: 0;
+}
+
+.switch {
+  position: relative;
+  display: inline-flex;
+  width: 46px;
+  height: 24px;
+}
+
+.switch input {
+  opacity: 0;
+  width: 0;
+  height: 0;
+}
+
+.slider {
+  position: absolute;
+  cursor: pointer;
+  inset: 0;
+  background-color: color-mix(in srgb, var(--border) 70%, var(--surface) 30%);
+  transition: background-color 0.2s ease;
+  border-radius: 999px;
+}
+
+.slider::before {
+  position: absolute;
+  content: '';
+  height: 18px;
+  width: 18px;
+  left: 3px;
+  bottom: 3px;
+  background-color: white;
+  transition: transform 0.2s ease;
+  border-radius: 50%;
+  box-shadow: 0 2px 4px rgba(0, 0, 0, 0.25);
+}
+
+.switch input:checked + .slider {
+  background-color: var(--accent);
+}
+
+.switch input:checked + .slider::before {
+  transform: translateX(22px);
+}
+
+[data-currency]::before {
+  content: attr(data-currency-prefix);
+}
+
+@media (max-width: 720px) {
+  .tab-panel {
+    padding: 1.25rem;
+  }
+
+  table {
+    min-width: 100%;
+  }
+
+  .line-items table,
+  .line-items thead,
+  .line-items tbody,
+  .line-items th,
+  .line-items td,
+  .line-items tr {
+    display: block;
+  }
+
+  .line-items thead {
+    display: none;
+  }
+
+  .line-items tr {
+    margin-bottom: 1rem;
+    border: 1px solid var(--border);
+    border-radius: 12px;
+    overflow: hidden;
+  }
+
+  .line-items td {
+    padding: 0.75rem;
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+  }
+
+  .line-items td::before {
+    content: attr(data-label);
+    font-weight: 600;
+    margin-right: 1rem;
+  }
+
+  .line-items td input {
+    width: 50%;
+  }
+
+  .line-total {
+    text-align: left;
+  }
+}


### PR DESCRIPTION
## Summary
- build invoice and quote builders with dynamic line items, GST toggles, and client linking
- persist clients, invoices, and quotes through a DataManager abstraction with automatic due/expiry calculations
- style the UI for responsiveness and wire up jsPDF-powered PDF exports for both modules

## Testing
- python3 -m http.server 8000

------
https://chatgpt.com/codex/tasks/task_e_68dd00a719408330ac766016a3b37eff