### PR TITLE
Add client management module backed by DataManager

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+node_modules/
+npm-debug.log*
+.DS_Store

--- a/README.md
+++ b/README.md
@@ -1,1 +1,46 @@
-# Zantra-Invoicing
+# Zantra Invoicing
+
+This project provides a file-backed data layer (`DataManager`) and a client management module (`ClientManager`) for managing client profiles and their services. Each client record captures:
+
+- Personal prefix (`Mr`, `Mrs`, or `Ms`)
+- Name and business details
+- Address and ABN
+- Contact number and email (validated and normalized)
+- A list of services with descriptions and hourly or fixed pricing information
+
+## Getting Started
+
+```bash
+npm install
+```
+
+## Running Tests
+
+```bash
+npm test
+```
+
+## Usage
+
+```js
+import { DataManager, ClientManager } from './src/index.js';
+
+const dataManager = new DataManager('./data/clients.json');
+const clientManager = new ClientManager(dataManager);
+
+const client = await clientManager.addClient({
+  prefix: 'Ms',
+  name: 'Jamie Doe',
+  businessName: 'Jamie Doe & Co',
+  address: '100 Example Street',
+  abn: '12 345 678 901',
+  contactNumber: '0400 123 456',
+  email: 'jamie@example.com',
+  services: [
+    {
+      description: 'Consulting',
+      pricing: { type: 'hourly', amount: 150 }
+    }
+  ]
+});
+```

--- a/package.json
+++ b/package.json
@@ -1,0 +1,16 @@
+{
+  "name": "zantra-invoicing",
+  "version": "1.0.0",
+  "description": "Client management module for Zantra Invoicing.",
+  "type": "module",
+  "main": "src/index.js",
+  "scripts": {
+    "test": "node --test"
+  },
+  "keywords": [
+    "invoicing",
+    "client-management"
+  ],
+  "author": "",
+  "license": "MIT"
+}

--- a/src/data/DataManager.js
+++ b/src/data/DataManager.js
@@ -1,0 +1,100 @@
+import { promises as fs } from 'fs';
+import { dirname, resolve } from 'path';
+
+const DEFAULT_ENCODING = 'utf-8';
+
+export class DataManager {
+  constructor(filePath) {
+    if (!filePath || typeof filePath !== 'string') {
+      throw new Error('DataManager requires a valid file path.');
+    }
+
+    this.filePath = resolve(filePath);
+    this.data = null;
+    this.initialized = false;
+  }
+
+  async ensureInitialized() {
+    if (this.initialized) {
+      return;
+    }
+
+    await this.ensureDirectory();
+    await this.ensureFile();
+    this.initialized = true;
+  }
+
+  async ensureDirectory() {
+    const directory = dirname(this.filePath);
+    await fs.mkdir(directory, { recursive: true });
+  }
+
+  async ensureFile() {
+    try {
+      await fs.access(this.filePath);
+    } catch (error) {
+      await fs.writeFile(this.filePath, '{}', DEFAULT_ENCODING);
+    }
+  }
+
+  async loadData() {
+    await this.ensureInitialized();
+    if (this.data) {
+      return this.data;
+    }
+
+    const raw = await fs.readFile(this.filePath, DEFAULT_ENCODING);
+    if (!raw.trim()) {
+      this.data = {};
+      return this.data;
+    }
+
+    try {
+      const parsed = JSON.parse(raw);
+      if (typeof parsed !== 'object' || parsed === null) {
+        throw new Error('Data file must contain a JSON object.');
+      }
+      this.data = parsed;
+      return this.data;
+    } catch (error) {
+      throw new Error(`Failed to parse data file: ${error.message}`);
+    }
+  }
+
+  async getCollection(collectionName) {
+    if (!collectionName) {
+      throw new Error('Collection name is required.');
+    }
+    const data = await this.loadData();
+    if (!Array.isArray(data[collectionName])) {
+      data[collectionName] = [];
+    }
+    return data[collectionName].map((item) => this.clone(item));
+  }
+
+  async saveCollection(collectionName, items) {
+    if (!collectionName) {
+      throw new Error('Collection name is required.');
+    }
+    if (!Array.isArray(items)) {
+      throw new Error('Collection items must be an array.');
+    }
+    const data = await this.loadData();
+    data[collectionName] = items.map((item) => this.clone(item));
+    await this.persist(data);
+    return data[collectionName].map((item) => this.clone(item));
+  }
+
+  async persist(updatedData) {
+    await this.ensureInitialized();
+    const serialized = JSON.stringify(updatedData, null, 2);
+    const tempPath = `${this.filePath}.tmp`;
+    await fs.writeFile(tempPath, serialized, DEFAULT_ENCODING);
+    await fs.rename(tempPath, this.filePath);
+    this.data = this.clone(updatedData);
+  }
+
+  clone(value) {
+    return JSON.parse(JSON.stringify(value));
+  }
+}

--- a/src/index.js
+++ b/src/index.js
@@ -1,0 +1,2 @@
+export { DataManager } from './data/DataManager.js';
+export { ClientManager } from './modules/client/ClientManager.js';

--- a/src/modules/client/ClientManager.js
+++ b/src/modules/client/ClientManager.js
@@ -1,0 +1,381 @@
+import { randomUUID } from 'crypto';
+
+const REQUIRED_STRING_FIELDS = [
+  { key: 'name', label: 'Client name' },
+  { key: 'businessName', label: 'Business name' },
+  { key: 'address', label: 'Address' },
+  { key: 'abn', label: 'ABN' },
+  { key: 'contactNumber', label: 'Contact number' },
+  { key: 'email', label: 'Email' }
+];
+
+const VALID_PREFIXES = ['Mr', 'Mrs', 'Ms'];
+const VALID_PRICING_TYPES = ['hourly', 'fixed'];
+
+export class ClientManager {
+  constructor(dataManager, { collectionName = 'clients' } = {}) {
+    if (!dataManager || typeof dataManager.getCollection !== 'function' || typeof dataManager.saveCollection !== 'function') {
+      throw new Error('ClientManager requires a DataManager instance.');
+    }
+
+    this.dataManager = dataManager;
+    this.collectionName = collectionName;
+  }
+
+  async listClients() {
+    return this.dataManager.getCollection(this.collectionName);
+  }
+
+  async getClientById(clientId) {
+    if (!clientId) {
+      throw new Error('Client ID is required.');
+    }
+    const clients = await this.dataManager.getCollection(this.collectionName);
+    return clients.find((client) => client.id === clientId) || null;
+  }
+
+  async addClient(clientInput) {
+    const clients = await this.dataManager.getCollection(this.collectionName);
+    const sanitized = this.normalizeClientInput(clientInput);
+    const timestamp = new Date().toISOString();
+    const client = {
+      ...sanitized,
+      id: randomUUID(),
+      createdAt: timestamp,
+      updatedAt: timestamp
+    };
+    clients.push(client);
+    await this.dataManager.saveCollection(this.collectionName, clients);
+    return client;
+  }
+
+  async updateClient(clientId, updates) {
+    if (!clientId) {
+      throw new Error('Client ID is required.');
+    }
+    if (!updates || typeof updates !== 'object') {
+      throw new Error('Updates must be an object.');
+    }
+
+    const clients = await this.dataManager.getCollection(this.collectionName);
+    const index = clients.findIndex((client) => client.id === clientId);
+    if (index === -1) {
+      throw new Error(`Client with ID ${clientId} was not found.`);
+    }
+
+    const existingClient = clients[index];
+    const updatedClient = {
+      ...this.normalizeClientInput({ ...existingClient, ...updates }, existingClient),
+      id: existingClient.id,
+      createdAt: existingClient.createdAt,
+      updatedAt: new Date().toISOString()
+    };
+
+    clients[index] = updatedClient;
+    await this.dataManager.saveCollection(this.collectionName, clients);
+    return updatedClient;
+  }
+
+  async removeClient(clientId) {
+    if (!clientId) {
+      throw new Error('Client ID is required.');
+    }
+    const clients = await this.dataManager.getCollection(this.collectionName);
+    const index = clients.findIndex((client) => client.id === clientId);
+    if (index === -1) {
+      throw new Error(`Client with ID ${clientId} was not found.`);
+    }
+    const [removed] = clients.splice(index, 1);
+    await this.dataManager.saveCollection(this.collectionName, clients);
+    return removed;
+  }
+
+  async addService(clientId, serviceInput) {
+    if (!clientId) {
+      throw new Error('Client ID is required.');
+    }
+    const clients = await this.dataManager.getCollection(this.collectionName);
+    const index = clients.findIndex((client) => client.id === clientId);
+    if (index === -1) {
+      throw new Error(`Client with ID ${clientId} was not found.`);
+    }
+
+    const client = clients[index];
+    const services = Array.isArray(client.services) ? [...client.services] : [];
+    const service = this.normalizeService(serviceInput);
+    services.push(service);
+
+    const updatedClient = {
+      ...client,
+      services,
+      updatedAt: new Date().toISOString()
+    };
+
+    clients[index] = updatedClient;
+    await this.dataManager.saveCollection(this.collectionName, clients);
+    return service;
+  }
+
+  async updateService(clientId, serviceId, updates) {
+    if (!clientId) {
+      throw new Error('Client ID is required.');
+    }
+    if (!serviceId) {
+      throw new Error('Service ID is required.');
+    }
+    if (!updates || typeof updates !== 'object') {
+      throw new Error('Updates must be an object.');
+    }
+
+    const clients = await this.dataManager.getCollection(this.collectionName);
+    const clientIndex = clients.findIndex((client) => client.id === clientId);
+    if (clientIndex === -1) {
+      throw new Error(`Client with ID ${clientId} was not found.`);
+    }
+
+    const client = clients[clientIndex];
+    const services = Array.isArray(client.services) ? [...client.services] : [];
+    const serviceIndex = services.findIndex((service) => service.id === serviceId);
+    if (serviceIndex === -1) {
+      throw new Error(`Service with ID ${serviceId} was not found for client ${clientId}.`);
+    }
+
+    const existingService = services[serviceIndex];
+    const updatedService = this.normalizeService({ ...existingService, ...updates }, existingService);
+    services[serviceIndex] = updatedService;
+
+    const updatedClient = {
+      ...client,
+      services,
+      updatedAt: new Date().toISOString()
+    };
+    clients[clientIndex] = updatedClient;
+    await this.dataManager.saveCollection(this.collectionName, clients);
+    return updatedService;
+  }
+
+  async removeService(clientId, serviceId) {
+    if (!clientId) {
+      throw new Error('Client ID is required.');
+    }
+    if (!serviceId) {
+      throw new Error('Service ID is required.');
+    }
+
+    const clients = await this.dataManager.getCollection(this.collectionName);
+    const clientIndex = clients.findIndex((client) => client.id === clientId);
+    if (clientIndex === -1) {
+      throw new Error(`Client with ID ${clientId} was not found.`);
+    }
+
+    const client = clients[clientIndex];
+    const services = Array.isArray(client.services) ? [...client.services] : [];
+    const serviceIndex = services.findIndex((service) => service.id === serviceId);
+    if (serviceIndex === -1) {
+      throw new Error(`Service with ID ${serviceId} was not found for client ${clientId}.`);
+    }
+
+    const [removed] = services.splice(serviceIndex, 1);
+    const updatedClient = {
+      ...client,
+      services,
+      updatedAt: new Date().toISOString()
+    };
+
+    clients[clientIndex] = updatedClient;
+    await this.dataManager.saveCollection(this.collectionName, clients);
+    return removed;
+  }
+
+  normalizeClientInput(input, existingClient = null) {
+    if (!input || typeof input !== 'object') {
+      throw new Error('Client payload must be an object.');
+    }
+
+    const merged = existingClient ? { ...existingClient, ...input } : { ...input };
+    const client = {};
+
+    this.applyPrefix(merged, client, existingClient);
+    this.applyStringFields(merged, client, existingClient);
+    this.applyEmail(merged, client, existingClient);
+    this.applyServices(merged, client, existingClient);
+
+    return client;
+  }
+
+  applyPrefix(source, target, existingClient) {
+    const value = source.prefix ?? source.title ?? existingClient?.prefix;
+    if (!value) {
+      throw new Error(`Prefix is required. Valid values: ${VALID_PREFIXES.join(', ')}.`);
+    }
+    const sanitized = String(value).trim();
+    if (!VALID_PREFIXES.includes(sanitized)) {
+      throw new Error(`Invalid prefix "${sanitized}". Valid values: ${VALID_PREFIXES.join(', ')}.`);
+    }
+    target.prefix = sanitized;
+  }
+
+  applyStringFields(source, target, existingClient) {
+    REQUIRED_STRING_FIELDS.forEach(({ key, label }) => {
+      const value = source[key];
+      if (value === undefined || value === null) {
+        const existingValue = existingClient?.[key];
+        if (!existingValue) {
+          throw new Error(`${label} is required.`);
+        }
+        target[key] = existingValue;
+        return;
+      }
+      if (typeof value !== 'string') {
+        throw new Error(`${label} must be a string.`);
+      }
+      const trimmed = value.trim();
+      if (!trimmed) {
+        throw new Error(`${label} cannot be empty.`);
+      }
+      if (key === 'contactNumber') {
+        this.validateContactNumber(trimmed);
+      }
+      if (key === 'abn') {
+        this.validateAbn(trimmed);
+      }
+      target[key] = trimmed;
+    });
+  }
+
+  applyEmail(source, target, existingClient) {
+    const email = target.email || source.email || existingClient?.email;
+    const trimmed = String(email).trim().toLowerCase();
+    if (!/^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(trimmed)) {
+      throw new Error('Email must be a valid email address.');
+    }
+    target.email = trimmed;
+  }
+
+  applyServices(source, target, existingClient) {
+    const services = source.services ?? existingClient?.services ?? [];
+    if (!Array.isArray(services)) {
+      throw new Error('Services must be provided as an array.');
+    }
+    const existingServices = existingClient?.services ?? [];
+    target.services = services.map((service) => this.normalizeService(service, existingServices.find((item) => item.id === service.id)));
+  }
+
+  validateContactNumber(value) {
+    const digits = value.replace(/\D/g, '');
+    if (digits.length < 6) {
+      throw new Error('Contact number must include at least six digits.');
+    }
+  }
+
+  validateAbn(value) {
+    const digits = value.replace(/\D/g, '');
+    if (digits.length !== 11) {
+      throw new Error('ABN must contain exactly 11 digits.');
+    }
+  }
+
+  normalizeService(serviceInput, existingService = null) {
+    if (!serviceInput || typeof serviceInput !== 'object') {
+      throw new Error('Service payload must be an object.');
+    }
+
+    const description = this.resolveServiceDescription(serviceInput, existingService);
+    const pricing = this.resolveServicePricing(serviceInput, existingService);
+
+    return {
+      id: existingService?.id ?? serviceInput.id ?? randomUUID(),
+      description,
+      pricing
+    };
+  }
+
+  resolveServiceDescription(serviceInput, existingService) {
+    const value = serviceInput.description ?? existingService?.description;
+    if (!value || typeof value !== 'string') {
+      throw new Error('Service description is required.');
+    }
+    const trimmed = value.trim();
+    if (!trimmed) {
+      throw new Error('Service description cannot be empty.');
+    }
+    return trimmed;
+  }
+
+  resolveServicePricing(serviceInput, existingService) {
+    const basePricing =
+      serviceInput.pricing && typeof serviceInput.pricing === 'object'
+        ? { ...serviceInput.pricing }
+        : {};
+
+    if (serviceInput.pricingType && basePricing.type === undefined) {
+      basePricing.type = serviceInput.pricingType;
+    }
+    if (serviceInput.type && basePricing.type === undefined) {
+      basePricing.type = serviceInput.type;
+    }
+
+    if (serviceInput.amount !== undefined) {
+      basePricing.amount = serviceInput.amount;
+    }
+    if (serviceInput.rate !== undefined && basePricing.amount === undefined) {
+      basePricing.amount = serviceInput.rate;
+    }
+    if (serviceInput.price !== undefined && basePricing.amount === undefined) {
+      basePricing.amount = serviceInput.price;
+    }
+    if (serviceInput.value !== undefined && basePricing.amount === undefined) {
+      basePricing.amount = serviceInput.value;
+    }
+
+    const existingPricing = existingService?.pricing ?? {};
+
+    const type = this.extractPricingType(basePricing, existingPricing);
+    const amount = this.extractPricingAmount(basePricing, existingPricing);
+
+    return { type, amount };
+  }
+
+  extractPricingType(pricing, existingPricing) {
+    const candidates = [pricing.type, pricing.pricingType, existingPricing.type];
+
+    const value = candidates.find((candidate) => typeof candidate === 'string');
+    if (!value) {
+      throw new Error(`Service pricing type is required. Valid values: ${VALID_PRICING_TYPES.join(', ')}.`);
+    }
+
+    const normalized = value.toLowerCase();
+    if (!VALID_PRICING_TYPES.includes(normalized)) {
+      throw new Error(`Invalid pricing type "${value}". Valid values: ${VALID_PRICING_TYPES.join(', ')}.`);
+    }
+    return normalized;
+  }
+
+  extractPricingAmount(pricing, existingPricing) {
+    const candidates = [pricing.amount, pricing.value, pricing.rate, existingPricing.amount];
+
+    const candidate = candidates.find((item) => this.isValidNumericCandidate(item));
+    if (candidate === undefined) {
+      throw new Error('Service pricing amount must be a finite number.');
+    }
+    const value = this.toNumber(candidate);
+    if (value <= 0) {
+      throw new Error('Service pricing amount must be greater than zero.');
+    }
+    return value;
+  }
+
+  isValidNumericCandidate(value) {
+    if (typeof value === 'number') {
+      return Number.isFinite(value);
+    }
+    if (typeof value === 'string') {
+      return value.trim() !== '' && Number.isFinite(Number(value));
+    }
+    return false;
+  }
+
+  toNumber(value) {
+    return typeof value === 'number' ? value : Number(value);
+  }
+}

--- a/tests/clientManager.test.js
+++ b/tests/clientManager.test.js
@@ -1,0 +1,157 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { mkdtemp, rm } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+import { DataManager } from '../src/data/DataManager.js';
+import { ClientManager } from '../src/modules/client/ClientManager.js';
+
+async function createManagers(t) {
+  const directory = await mkdtemp(join(tmpdir(), 'client-mgr-'));
+  const dataFile = join(directory, 'store.json');
+  const dataManager = new DataManager(dataFile);
+  const clientManager = new ClientManager(dataManager);
+  t.after(async () => {
+    await rm(directory, { recursive: true, force: true });
+  });
+  return { dataManager, clientManager };
+}
+
+test('adds a client with services', async (t) => {
+  const { clientManager } = await createManagers(t);
+  const client = await clientManager.addClient({
+    prefix: 'Mr',
+    name: 'John Doe',
+    businessName: 'Doe Consulting',
+    address: '123 Business Rd',
+    abn: '12 345 678 901',
+    contactNumber: '+61 400 000 000',
+    email: 'JOHN@EXAMPLE.COM',
+    services: [
+      {
+        description: 'Consulting',
+        pricing: { type: 'hourly', amount: 150 }
+      }
+    ]
+  });
+
+  assert.ok(client.id, 'Client should receive an ID');
+  assert.equal(client.email, 'john@example.com');
+  assert.equal(client.services.length, 1);
+  assert.ok(client.services[0].id, 'Service should receive an ID');
+  assert.equal(client.services[0].pricing.type, 'hourly');
+  assert.equal(client.services[0].pricing.amount, 150);
+
+  const storedClients = await clientManager.listClients();
+  assert.equal(storedClients.length, 1);
+});
+
+test('updates an existing client and services', async (t) => {
+  const { clientManager } = await createManagers(t);
+  const client = await clientManager.addClient({
+    prefix: 'Ms',
+    name: 'Jane Smith',
+    businessName: 'Smith Creative',
+    address: '456 Market Ave',
+    abn: '98 765 432 109',
+    contactNumber: '0400 123 456',
+    email: 'contact@smithcreative.com',
+    services: [
+      {
+        description: 'Design',
+        pricingType: 'fixed',
+        price: 2500
+      }
+    ]
+  });
+
+  const updated = await clientManager.updateClient(client.id, {
+    prefix: 'Mrs',
+    email: 'UPDATED@SMITHCREATIVE.COM',
+    services: client.services.map((service) => ({
+      ...service,
+      pricing: { type: 'fixed', amount: 3000 }
+    }))
+  });
+
+  assert.equal(updated.prefix, 'Mrs');
+  assert.equal(updated.email, 'updated@smithcreative.com');
+  assert.equal(updated.services[0].pricing.amount, 3000);
+});
+
+test('rejects invalid prefixes', async (t) => {
+  const { clientManager } = await createManagers(t);
+  await assert.rejects(
+    () =>
+      clientManager.addClient({
+        prefix: 'Dr',
+        name: 'Invalid Prefix',
+        businessName: 'Test Pty Ltd',
+        address: '789 Example St',
+        abn: '11 111 111 111',
+        contactNumber: '0400 000 001',
+        email: 'invalid@example.com',
+        services: []
+      }),
+    /Invalid prefix/
+  );
+});
+
+test('manages services lifecycle for a client', async (t) => {
+  const { clientManager } = await createManagers(t);
+  const client = await clientManager.addClient({
+    prefix: 'Mr',
+    name: 'Service Manager',
+    businessName: 'Service Co',
+    address: '101 Service Way',
+    abn: '22 222 222 222',
+    contactNumber: '0400 222 222',
+    email: 'services@example.com',
+    services: []
+  });
+
+  const newService = await clientManager.addService(client.id, {
+    description: 'Maintenance',
+    pricing: { type: 'hourly', amount: 120 }
+  });
+
+  assert.ok(newService.id);
+
+  const updatedService = await clientManager.updateService(client.id, newService.id, {
+    amount: 150,
+    pricingType: 'hourly'
+  });
+
+  assert.equal(updatedService.pricing.amount, 150);
+
+  const removed = await clientManager.removeService(client.id, newService.id);
+  assert.equal(removed.id, newService.id);
+
+  const refreshed = await clientManager.getClientById(client.id);
+  assert.equal(refreshed.services.length, 0);
+});
+
+test('rejects invalid service pricing amount', async (t) => {
+  const { clientManager } = await createManagers(t);
+
+  await assert.rejects(
+    () =>
+      clientManager.addClient({
+        prefix: 'Ms',
+        name: 'Bad Pricing',
+        businessName: 'Error Inc',
+        address: '404 Error Blvd',
+        abn: '33 333 333 333',
+        contactNumber: '0400 333 333',
+        email: 'error@example.com',
+        services: [
+          {
+            description: 'Bug Fixing',
+            pricing: { type: 'hourly', amount: 0 }
+          }
+        ]
+      }),
+    /greater than zero/
+  );
+});


### PR DESCRIPTION
## Summary
- implement a file-backed `DataManager` to provide reusable JSON persistence helpers
- add a `ClientManager` that validates client metadata, enforces service pricing rules, and integrates with the data layer
- document the workflow and cover key behaviours with automated Node tests

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68dd00aef9888330a0abdd9f0d79ecbb