### PR TITLE
Add data backup export and restore controls

### DIFF
--- a/index.html
+++ b/index.html
@@ -896,6 +896,20 @@
                 <button class="btn btn--primary btn--lg save-settings-btn" type="submit">Save settings</button>
               </div>
             </form>
+            <section class="card settings-backup-card" aria-labelledby="settings-backup-title">
+              <header class="card__header">
+                <h2 id="settings-backup-title" class="card__title">Backup &amp; restore</h2>
+                <p class="card__subtitle">Download a full JSON backup or restore your invoicing data.</p>
+              </header>
+              <div class="card__body">
+                <div class="settings-backup-card__actions">
+                  <button type="button" class="btn btn--secondary btn--md" data-action="export-backup">Export backup</button>
+                  <button type="button" class="btn btn--ghost btn--md" data-action="restore-backup">Restore backup</button>
+                  <input type="file" accept="application/json" data-backup-input hidden />
+                </div>
+                <p class="settings-backup-card__status" role="status" aria-live="polite" data-backup-feedback></p>
+              </div>
+            </section>
           </section>
     </div>
   </main>

--- a/src/index.js
+++ b/src/index.js
@@ -14,6 +14,7 @@ import { QuoteManager } from './managers/QuoteManager.js';
 import { PaymentManager } from './managers/PaymentManager.js';
 import { ReportManager } from './managers/ReportManager.js';
 import { SettingsManager } from './managers/SettingsManager.js';
+import { BackupManager } from './managers/BackupManager.js';
 
 const currencyFormatter = new Intl.NumberFormat(undefined, {
   style: 'currency',
@@ -291,6 +292,7 @@ class ZantraApp {
     this.cacheDom();
     this.setupNavigation();
     this.bindHeaderActions();
+    this.bindBackupActions();
     this.refreshData();
     this.renderAll();
     this.exposeGlobals();
@@ -335,6 +337,10 @@ class ZantraApp {
     this.paymentHistoryBody = document.querySelector('[data-table="payments-history"] tbody');
 
     this.settingsForm = document.querySelector('#settings-form');
+    this.backupExportButton = document.querySelector('[data-action="export-backup"]');
+    this.backupRestoreButton = document.querySelector('[data-action="restore-backup"]');
+    this.backupFileInput = document.querySelector('[data-backup-input]');
+    this.backupStatus = document.querySelector('[data-backup-feedback]');
     this.reportCanvas = document.getElementById('reports-chart');
 
     this.toastRegion = document.querySelector('[data-toast-region]');
@@ -460,6 +466,107 @@ class ZantraApp {
         event.preventDefault();
         this.activateSection('quotes');
         this.toggleQuoteForm(true);
+      });
+    }
+  }
+
+  bindBackupActions() {
+    if (!this.backupExportButton && !this.backupRestoreButton) {
+      return;
+    }
+
+    const setLoading = (loading) => {
+      const isLoading = Boolean(loading);
+      const controls = [this.backupExportButton, this.backupRestoreButton];
+      controls.forEach((control) => {
+        if (control) {
+          control.disabled = isLoading;
+          control.setAttribute('aria-busy', isLoading ? 'true' : 'false');
+        }
+      });
+      if (this.backupStatus) {
+        this.backupStatus.setAttribute('aria-busy', isLoading ? 'true' : 'false');
+      }
+    };
+
+    const setStatus = (message = '', state = 'idle') => {
+      if (!this.backupStatus) {
+        return;
+      }
+      this.backupStatus.textContent = message;
+      if (!state || state === 'idle') {
+        this.backupStatus.removeAttribute('data-state');
+      } else {
+        this.backupStatus.setAttribute('data-state', state);
+      }
+    };
+
+    const describeExportedAt = (value) => {
+      if (!value) {
+        return '';
+      }
+      const parsed = Date.parse(value);
+      if (Number.isNaN(parsed)) {
+        return '';
+      }
+      const date = new Date(parsed);
+      return `${date.toLocaleDateString()} ${date.toLocaleTimeString()}`;
+    };
+
+    setStatus('', 'idle');
+    setLoading(false);
+
+    if (this.backupExportButton) {
+      this.backupExportButton.addEventListener('click', async (event) => {
+        event.preventDefault();
+        try {
+          setLoading(true);
+          setStatus('Preparing backup...', 'loading');
+          const payload = await BackupManager.downloadBackup();
+          const exportedAt = describeExportedAt(payload.exportedAt);
+          setStatus(
+            exportedAt ? `Backup downloaded (${exportedAt}). Keep it in a safe place.` : 'Backup downloaded. Keep it in a safe place.',
+            'success'
+          );
+        } catch (error) {
+          console.error(error);
+          setStatus(error.message || 'Failed to export backup.', 'error');
+        } finally {
+          setLoading(false);
+        }
+      });
+    }
+
+    if (this.backupRestoreButton && this.backupFileInput) {
+      this.backupRestoreButton.addEventListener('click', (event) => {
+        event.preventDefault();
+        this.backupFileInput.click();
+      });
+
+      this.backupFileInput.addEventListener('change', async (event) => {
+        const [file] = event.target.files || [];
+        if (!file) {
+          setStatus('', 'idle');
+          return;
+        }
+        try {
+          setLoading(true);
+          setStatus('Restoring backup...', 'loading');
+          const payload = await BackupManager.restoreBackup(file);
+          const exportedAt = describeExportedAt(payload.exportedAt);
+          setStatus(
+            exportedAt ? `Backup restored (${exportedAt}).` : 'Backup restored successfully.',
+            'success'
+          );
+          this.refreshData();
+          this.renderAll();
+        } catch (error) {
+          console.error(error);
+          setStatus(error.message || 'Failed to restore backup.', 'error');
+        } finally {
+          setLoading(false);
+          this.backupFileInput.value = '';
+        }
       });
     }
   }
@@ -1604,7 +1711,8 @@ class ZantraApp {
         QuoteManager,
         PaymentManager,
         ReportManager,
-        SettingsManager
+        SettingsManager,
+        BackupManager
       };
     }
   }
@@ -1623,5 +1731,6 @@ export {
   QuoteManager,
   PaymentManager,
   ReportManager,
-  SettingsManager
+  SettingsManager,
+  BackupManager
 };

--- a/src/managers/BackupManager.js
+++ b/src/managers/BackupManager.js
@@ -1,0 +1,70 @@
+import { DataManager } from '../data/DataManager.js';
+
+const BACKUP_MIME_TYPE = 'application/json';
+const BACKUP_FILENAME_PREFIX = 'zantra-backup';
+
+const resolveDocument = () => (typeof document !== 'undefined' ? document : null);
+
+const createTimestampedFilename = () => {
+  const timestamp = new Date().toISOString().replace(/[:.]/g, '-');
+  return `${BACKUP_FILENAME_PREFIX}-${timestamp}.json`;
+};
+
+const triggerDownload = (blob, filename) => {
+  const doc = resolveDocument();
+  if (!doc) {
+    throw new Error('Unable to initiate download in this environment.');
+  }
+  if (typeof URL === 'undefined' || typeof URL.createObjectURL !== 'function') {
+    throw new Error('File downloads are not supported in this environment.');
+  }
+  const url = URL.createObjectURL(blob);
+  try {
+    const anchor = doc.createElement('a');
+    anchor.href = url;
+    anchor.download = filename;
+    anchor.rel = 'noopener';
+    anchor.style.display = 'none';
+    doc.body.appendChild(anchor);
+    anchor.click();
+    doc.body.removeChild(anchor);
+  } finally {
+    URL.revokeObjectURL(url);
+  }
+};
+
+export class BackupManager {
+  static async downloadBackup() {
+    const payload = DataManager.exportAll();
+    const serialized = JSON.stringify(payload, null, 2);
+    const blob = new Blob([serialized], { type: BACKUP_MIME_TYPE });
+    triggerDownload(blob, createTimestampedFilename());
+    return payload;
+  }
+
+  static async restoreBackup(file) {
+    if (!file) {
+      throw new Error('Select a backup file to restore.');
+    }
+    if (typeof file.size === 'number' && file.size === 0) {
+      throw new Error('The selected backup file is empty.');
+    }
+    let raw;
+    try {
+      if (typeof file.text === 'function') {
+        raw = await file.text();
+      } else if (typeof file.arrayBuffer === 'function') {
+        raw = await file.arrayBuffer();
+      } else {
+        throw new Error('Unsupported backup file type.');
+      }
+    } catch (error) {
+      throw new Error('Unable to read the selected backup file.');
+    }
+    const payload = DataManager.parseBackupPayload(raw);
+    DataManager.restoreAll(payload);
+    return payload;
+  }
+}
+
+export default BackupManager;

--- a/styles/styles.css
+++ b/styles/styles.css
@@ -329,6 +329,17 @@ small,
   border-bottom: 1px solid rgba(255, 255, 255, 0.08);
 }
 
+.card__title {
+  font-size: var(--text-lg);
+  margin: 0;
+}
+
+.card__subtitle {
+  margin: var(--space-2) 0 0;
+  color: var(--muted);
+  font-size: var(--text-sm);
+}
+
 .card__header--toolbar {
   display: flex;
   flex-wrap: wrap;
@@ -695,6 +706,35 @@ textarea {
 
 .form-feedback {
   min-height: 1.25em;
+  color: #ff94a6;
+}
+
+.settings-backup-card {
+  margin-top: var(--space-6);
+}
+
+.settings-backup-card__actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--space-3);
+  align-items: center;
+}
+
+.settings-backup-card__status {
+  min-height: 1.25em;
+  font-size: var(--text-sm);
+  color: var(--muted);
+}
+
+.settings-backup-card__status[data-state='loading'] {
+  color: var(--accent-2);
+}
+
+.settings-backup-card__status[data-state='success'] {
+  color: #34d399;
+}
+
+.settings-backup-card__status[data-state='error'] {
   color: #ff94a6;
 }
 


### PR DESCRIPTION
## Summary
- add DataManager helpers to snapshot and restore all collections with schema validation and rollback safety
- introduce a BackupManager to drive JSON backup download/upload flows
- expose export and restore controls in the Settings tab with styling and live status messaging

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68df10b242988330aab98e6e48810fe7