### PR TITLE
Add recurring invoice scheduling and automation

### DIFF
--- a/index.html
+++ b/index.html
@@ -206,6 +206,14 @@
                 <ul class="timeline" data-dashboard-outstanding aria-live="polite"></ul>
               </div>
             </article>
+            <article class="card card--elev">
+              <header class="card__header">
+                <h2 class="card__title">Recurring reminders</h2>
+              </header>
+              <div class="card__body">
+                <ul class="timeline" data-dashboard-recurring aria-live="polite"></ul>
+              </div>
+            </article>
           </section>
 
           <section
@@ -225,6 +233,10 @@
               <div class="section__actions">
                 <button class="btn btn--primary btn--md" type="button" data-action="open-invoice-form">
                   Create invoice
+                </button>
+                <button class="btn btn--secondary btn--md" type="button" data-action="open-recurring-form">
+                  <span class="btn__icon" aria-hidden="true">⏱️</span>
+                  <span>New recurring schedule</span>
                 </button>
               </div>
             </header>
@@ -340,6 +352,153 @@
                           <th scope="col">Due</th>
                           <th scope="col" class="text-right">Total</th>
                           <th scope="col">Status</th>
+                          <th scope="col" class="text-right">Actions</th>
+                        </tr>
+                      </thead>
+                      <tbody></tbody>
+                    </table>
+                  </div>
+                </div>
+              </div>
+            </div>
+            <form id="recurring-form" class="form card" data-form="recurring" hidden>
+              <input type="hidden" name="scheduleId" />
+              <div class="form-layout">
+                <div class="form-layout__main">
+                  <div class="row row--g16 form-row">
+                    <div class="field field--grow field--lg">
+                      <label for="recurring-name">Schedule name</label>
+                      <input id="recurring-name" type="text" name="name" placeholder="e.g. Monthly maintenance" required />
+                    </div>
+                    <div class="field field--grow field--lg">
+                      <label for="recurring-client">Client</label>
+                      <select id="recurring-client" name="clientId" required></select>
+                    </div>
+                  </div>
+
+                  <div class="row row--g16 form-row">
+                    <div class="field field--auto">
+                      <label for="recurring-start">Start date</label>
+                      <input id="recurring-start" type="date" name="startDate" required />
+                    </div>
+                    <div class="field field--auto">
+                      <label for="recurring-next">Next invoice date</label>
+                      <input id="recurring-next" type="date" name="nextRun" required />
+                    </div>
+                    <div class="field field--auto">
+                      <label for="recurring-frequency">Frequency</label>
+                      <select id="recurring-frequency" name="frequency" required></select>
+                    </div>
+                    <div class="field field--auto">
+                      <label for="recurring-due-days">Due in (days)</label>
+                      <input
+                        id="recurring-due-days"
+                        type="number"
+                        name="dueDays"
+                        min="1"
+                        max="90"
+                        step="1"
+                        value="14"
+                        required
+                      />
+                    </div>
+                  </div>
+
+                  <div class="card card--subtle">
+                    <header class="card__header">
+                      <h2 class="card__title">Line items</h2>
+                    </header>
+                    <div class="card__body">
+                      <div class="table table--line-items">
+                        <div class="table__container">
+                          <table>
+                            <thead>
+                              <tr>
+                                <th scope="col">Service</th>
+                                <th scope="col">Description</th>
+                                <th scope="col">Qty</th>
+                                <th scope="col">Unit price</th>
+                                <th scope="col">GST</th>
+                                <th scope="col" class="text-right">Row total</th>
+                                <th scope="col" class="sr-only">Actions</th>
+                              </tr>
+                            </thead>
+                            <tbody data-line-items-body></tbody>
+                          </table>
+                        </div>
+                        <div class="table__footer">
+                          <button
+                            class="btn btn--secondary btn--md btn--full"
+                            type="button"
+                            data-action="add-line"
+                          >
+                            Add line item
+                          </button>
+                        </div>
+                      </div>
+                    </div>
+                  </div>
+
+                  <div class="field field--stack">
+                    <label for="recurring-notes">Notes</label>
+                    <textarea
+                      id="recurring-notes"
+                      name="notes"
+                      rows="3"
+                      placeholder="Default notes applied to generated invoices"
+                    ></textarea>
+                  </div>
+                </div>
+                <aside class="form-layout__aside">
+                  <div class="totals card card--elev" aria-live="polite">
+                    <header class="card__header">
+                      <h2 class="card__title">Estimated totals</h2>
+                    </header>
+                    <div class="card__body">
+                      <dl class="totals__list">
+                        <div class="totals__row">
+                          <dt>Subtotal</dt>
+                          <dd data-recurring-total="subtotal">$0.00</dd>
+                        </div>
+                        <div class="totals__row">
+                          <dt>GST</dt>
+                          <dd data-recurring-total="gst">$0.00</dd>
+                        </div>
+                        <div class="totals__row totals__row--grand">
+                          <dt>Total</dt>
+                          <dd data-recurring-total="total">$0.00</dd>
+                        </div>
+                      </dl>
+                    </div>
+                  </div>
+                </aside>
+              </div>
+              <p class="form-feedback" data-feedback role="alert"></p>
+              <div class="form-actions">
+                <button class="btn btn--primary btn--lg save-recurring-btn" type="submit">
+                  Save schedule
+                </button>
+                <button class="btn btn--secondary btn--lg" type="button" data-action="cancel">
+                  Cancel
+                </button>
+              </div>
+            </form>
+            <div class="card card--table" data-table="recurring" role="region" aria-live="polite">
+              <header class="card__header card__header--toolbar">
+                <h2 class="card__title">Recurring schedules</h2>
+              </header>
+              <div class="card__body">
+                <div class="table">
+                  <div class="table__container">
+                    <table>
+                      <caption class="sr-only">List of recurring invoice schedules</caption>
+                      <thead>
+                        <tr>
+                          <th scope="col">Schedule</th>
+                          <th scope="col">Client</th>
+                          <th scope="col">Frequency</th>
+                          <th scope="col">Next run</th>
+                          <th scope="col">Last run</th>
                           <th scope="col" class="text-right">Actions</th>
                         </tr>
                       </thead>

--- a/src/data/DataManager.js
+++ b/src/data/DataManager.js
@@ -6,7 +6,8 @@ const COLLECTION_KEYS = {
   clients: 'clients',
   services: 'services',
   payments: 'payments',
-  settings: 'settings'
+  settings: 'settings',
+  recurringSchedules: 'recurringSchedules'
 };
 
 const DEFAULT_SETTINGS = {
@@ -220,6 +221,18 @@ export class DataManager {
 
   static deletePayment(paymentId) {
     return DataManager.#deleteRecord(COLLECTION_KEYS.payments, paymentId);
+  }
+
+  static listRecurringSchedules() {
+    return DataManager.#getCollection(COLLECTION_KEYS.recurringSchedules);
+  }
+
+  static saveRecurringSchedule(schedule) {
+    return DataManager.#saveRecord(COLLECTION_KEYS.recurringSchedules, schedule);
+  }
+
+  static deleteRecurringSchedule(scheduleId) {
+    return DataManager.#deleteRecord(COLLECTION_KEYS.recurringSchedules, scheduleId);
   }
 
   static #getCollection(key) {

--- a/src/index.js
+++ b/src/index.js
@@ -14,6 +14,7 @@ import { QuoteManager } from './managers/QuoteManager.js';
 import { PaymentManager } from './managers/PaymentManager.js';
 import { ReportManager } from './managers/ReportManager.js';
 import { SettingsManager } from './managers/SettingsManager.js';
+import { RecurringInvoiceManager } from './managers/RecurringInvoiceManager.js';
 
 const currencyFormatter = new Intl.NumberFormat(undefined, {
   style: 'currency',
@@ -275,15 +276,18 @@ class ZantraApp {
       invoices: [],
       quotes: [],
       payments: [],
+      recurringSchedules: [],
       settings: SettingsManager.get()
     };
     this.reportChart = null;
     this.invoiceFormInitialized = false;
     this.quoteFormInitialized = false;
+    this.recurringFormInitialized = false;
     this.clientFormInitialized = false;
     this.serviceFormInitialized = false;
     this.settingsFormInitialized = false;
     this.toastDismissTimeout = null;
+    this.recentlyGeneratedRecurringInvoices = [];
     this.handleQuoteListClick = this.handleQuoteListClick.bind(this);
   }
 
@@ -308,6 +312,7 @@ class ZantraApp {
     this.resumeSetupButton = document.querySelector('.resume-setup-btn');
     this.newInvoiceButton = document.querySelector('.new-invoice-btn');
     this.sectionInvoiceButtons = Array.from(document.querySelectorAll('[data-action="open-invoice-form"]'));
+    this.newRecurringButton = document.querySelector('[data-action="open-recurring-form"]');
     this.newQuoteButton = document.querySelector('[data-action="open-quote-form"]');
 
     this.dashboardMetrics = {
@@ -318,9 +323,13 @@ class ZantraApp {
     };
 
     this.dashboardOutstandingList = document.querySelector('[data-dashboard-outstanding]');
+    this.dashboardRecurringList = document.querySelector('[data-dashboard-recurring]');
 
     this.invoiceForm = document.querySelector('#invoice-form');
     this.invoiceListBody = document.querySelector('[data-table="invoices"] tbody');
+
+    this.recurringForm = document.querySelector('#recurring-form');
+    this.recurringListBody = document.querySelector('[data-table="recurring"] tbody');
 
     this.quoteForm = document.querySelector('#quote-form');
     this.quoteListBody = document.querySelector('[data-table="quotes"] tbody');
@@ -349,6 +358,15 @@ class ZantraApp {
       services: this.state.services,
       gstRate: this.state.settings.gstRate
     });
+    if (this.recurringForm) {
+      this.recurringFormEditor = new LineItemEditor(this.recurringForm, {
+        onTotalsChange: (items) => this.updateRecurringTotals(items),
+        services: this.state.services,
+        gstRate: this.state.settings.gstRate
+      });
+    } else {
+      this.recurringFormEditor = null;
+    }
 
     if (this.quoteListBody) {
       this.quoteListBody.addEventListener('click', this.handleQuoteListClick);
@@ -455,6 +473,13 @@ class ZantraApp {
         });
       });
     }
+    if (this.newRecurringButton) {
+      this.newRecurringButton.addEventListener('click', (event) => {
+        event.preventDefault();
+        this.activateSection('invoices');
+        this.toggleRecurringForm(true);
+      });
+    }
     if (this.newQuoteButton) {
       this.newQuoteButton.addEventListener('click', (event) => {
         event.preventDefault();
@@ -465,6 +490,7 @@ class ZantraApp {
   }
 
   refreshData() {
+    this.recentlyGeneratedRecurringInvoices = RecurringInvoiceManager.executeDueSchedules();
     this.state.clients = ClientManager.list();
     this.state.services = ServiceManager.list();
     this.state.invoices = InvoiceManager.list().map((invoice) => ({
@@ -476,23 +502,30 @@ class ZantraApp {
       type: quote.type || 'quote'
     }));
     this.state.payments = PaymentManager.list();
+    this.state.recurringSchedules = RecurringInvoiceManager.list();
     this.state.settings = SettingsManager.get();
 
     this.invoiceFormEditor.refreshServices(this.state.services);
     this.quoteFormEditor.refreshServices(this.state.services);
     this.invoiceFormEditor.gstRate = this.state.settings.gstRate;
     this.quoteFormEditor.gstRate = this.state.settings.gstRate;
+    if (this.recurringFormEditor) {
+      this.recurringFormEditor.refreshServices(this.state.services);
+      this.recurringFormEditor.gstRate = this.state.settings.gstRate;
+    }
   }
 
   renderAll() {
     this.renderDashboard();
     this.renderInvoices();
+    this.renderRecurringSchedules();
     this.renderQuotes();
     this.renderClients();
     this.renderServices();
     this.renderPayments();
     this.renderReports();
     this.renderSettings();
+    this.notifyRecurringGeneration();
   }
 
   renderDashboard() {
@@ -528,6 +561,59 @@ class ZantraApp {
         });
       }
     }
+
+    if (this.dashboardRecurringList) {
+      clearChildren(this.dashboardRecurringList);
+      const upcoming = this.state.recurringSchedules
+        .filter((schedule) => schedule.nextRun)
+        .sort((a, b) => Date.parse(a.nextRun) - Date.parse(b.nextRun));
+      if (!upcoming.length) {
+        const empty = document.createElement('li');
+        empty.textContent = 'No recurring invoices scheduled.';
+        this.dashboardRecurringList.appendChild(empty);
+      } else {
+        const now = Date.now();
+        upcoming.slice(0, 5).forEach((schedule) => {
+          const nextRunTime = Date.parse(schedule.nextRun);
+          const status = Number.isNaN(nextRunTime)
+            ? 'Scheduled'
+            : nextRunTime < now
+            ? 'Overdue'
+            : 'Due';
+          const label = `${status} ${formatDate(schedule.nextRun)}`;
+          const item = document.createElement('li');
+          item.innerHTML = `<strong>${schedule.name}</strong> · ${schedule.clientBusinessName || schedule.clientName} · ${
+            schedule.frequencyLabel
+          } · ${label}`;
+          this.dashboardRecurringList.appendChild(item);
+        });
+      }
+    }
+  }
+
+  notifyRecurringGeneration() {
+    if (!Array.isArray(this.recentlyGeneratedRecurringInvoices)) {
+      return;
+    }
+    const results = this.recentlyGeneratedRecurringInvoices;
+    if (!results.length) {
+      return;
+    }
+
+    const count = results.length;
+    const names = Array.from(
+      new Set(
+        results
+          .map((result) => result?.schedule?.name || '')
+          .filter((name) => typeof name === 'string' && name.trim())
+      )
+    );
+    const displayedNames = names.slice(0, 3).join(', ');
+    const moreSuffix = names.length > 3 ? ', …' : '';
+    const scheduleSummary = names.length ? ` from ${displayedNames}${moreSuffix}` : '';
+    const message = `Generated ${count} recurring invoice${count === 1 ? '' : 's'}${scheduleSummary}.`;
+    this.showToast(message, 'success');
+    this.recentlyGeneratedRecurringInvoices = [];
   }
 
   toggleInvoiceForm(visible, invoice = null) {
@@ -611,6 +697,113 @@ class ZantraApp {
       this.invoiceFormEditor.addRow();
     }
     this.updateInvoiceTotals(invoice.lineItems || []);
+  }
+
+  toggleRecurringForm(visible, schedule = null) {
+    if (!this.recurringForm) {
+      return;
+    }
+    const feedback = this.recurringForm.querySelector('[data-feedback]');
+    if (feedback) {
+      feedback.textContent = '';
+    }
+    const idField = this.recurringForm.querySelector('[name="scheduleId"]');
+    if (!visible) {
+      this.recurringFormEditor?.removeAll();
+      this.recurringForm.reset();
+      this.updateRecurringTotals([]);
+      toggleHidden(this.recurringForm, true);
+      if (idField) {
+        idField.value = '';
+      }
+      delete this.recurringForm.dataset.mode;
+      return;
+    }
+
+    toggleHidden(this.recurringForm, false);
+    this.recurringForm.reset();
+    this.recurringFormEditor?.removeAll();
+
+    if (schedule) {
+      this.recurringForm.dataset.mode = 'edit';
+      if (idField) {
+        idField.value = schedule.id;
+      }
+      this.populateRecurringForm(schedule);
+    } else {
+      this.recurringForm.dataset.mode = 'create';
+      if (idField) {
+        idField.value = '';
+      }
+      const today = new Date();
+      const startInput = this.recurringForm.querySelector('[name="startDate"]');
+      const nextInput = this.recurringForm.querySelector('[name="nextRun"]');
+      setDateInputValue(startInput, today);
+      setDateInputValue(nextInput, today);
+      const dueDaysInput = this.recurringForm.querySelector('[name="dueDays"]');
+      if (dueDaysInput) {
+        dueDaysInput.value = '14';
+      }
+      const frequencySelect = this.recurringForm.querySelector('[name="frequency"]');
+      if (frequencySelect && !frequencySelect.value) {
+        const options = RecurringInvoiceManager.getFrequencyOptions();
+        if (options.length) {
+          const preferred = options.find((option) => option.value === 'monthly') || options[0];
+          frequencySelect.value = preferred.value;
+        }
+      }
+      this.recurringFormEditor?.addRow();
+      this.updateRecurringTotals(this.recurringFormEditor ? this.recurringFormEditor.getItems() : []);
+    }
+
+    const nameInput = this.recurringForm.querySelector('[name="name"]');
+    nameInput?.focus();
+    this.recurringForm.scrollIntoView({ behavior: 'smooth', block: 'start' });
+  }
+
+  populateRecurringForm(schedule) {
+    if (!this.recurringForm || !schedule) {
+      return;
+    }
+    const nameInput = this.recurringForm.querySelector('[name="name"]');
+    if (nameInput) {
+      nameInput.value = schedule.name || '';
+    }
+    const clientSelect = this.recurringForm.querySelector('[name="clientId"]');
+    if (clientSelect) {
+      clientSelect.value = schedule.clientId || '';
+    }
+    const startInput = this.recurringForm.querySelector('[name="startDate"]');
+    const nextInput = this.recurringForm.querySelector('[name="nextRun"]');
+    setDateInputValue(startInput, schedule.startDate);
+    setDateInputValue(nextInput, schedule.nextRun || schedule.startDate);
+    const frequencySelect = this.recurringForm.querySelector('[name="frequency"]');
+    if (frequencySelect) {
+      frequencySelect.value = schedule.frequency || frequencySelect.value;
+    }
+    const dueDaysInput = this.recurringForm.querySelector('[name="dueDays"]');
+    if (dueDaysInput) {
+      dueDaysInput.value = Number.parseInt(schedule.dueDays, 10) || 14;
+    }
+    const notesInput = this.recurringForm.querySelector('[name="notes"]');
+    if (notesInput) {
+      notesInput.value = schedule.notes || '';
+    }
+
+    if (Array.isArray(schedule.lineItems) && schedule.lineItems.length) {
+      schedule.lineItems.forEach((item) => {
+        this.recurringFormEditor?.addRow({
+          serviceId: item.serviceId,
+          description: item.description,
+          quantity: item.quantity,
+          unitPrice: item.unitPrice,
+          applyGst: item.applyGst
+        });
+      });
+    } else {
+      this.recurringFormEditor?.addRow();
+    }
+    this.updateRecurringTotals(schedule.lineItems || []);
   }
 
   toggleQuoteForm(visible, quote = null) {
@@ -701,6 +894,20 @@ class ZantraApp {
     const subtotal = this.invoiceForm.querySelector('[data-total="subtotal"]');
     const gst = this.invoiceForm.querySelector('[data-total="gst"]');
     const total = this.invoiceForm.querySelector('[data-total="total"]');
+    if (subtotal) subtotal.textContent = formatCurrency(totals.subtotal);
+    if (gst) gst.textContent = formatCurrency(totals.gstTotal);
+    if (total) total.textContent = formatCurrency(totals.total);
+  }
+
+  updateRecurringTotals(items) {
+    if (!this.recurringForm) {
+      return;
+    }
+    const lineItems = Array.isArray(items) ? items : [];
+    const totals = InvoiceManager.calculateTotals(lineItems, this.state.settings.gstRate);
+    const subtotal = this.recurringForm.querySelector('[data-recurring-total="subtotal"]');
+    const gst = this.recurringForm.querySelector('[data-recurring-total="gst"]');
+    const total = this.recurringForm.querySelector('[data-recurring-total="total"]');
     if (subtotal) subtotal.textContent = formatCurrency(totals.subtotal);
     if (gst) gst.textContent = formatCurrency(totals.gstTotal);
     if (total) total.textContent = formatCurrency(totals.total);
@@ -839,6 +1046,161 @@ class ZantraApp {
     }
   }
 
+  renderRecurringSchedules() {
+    if (!this.recurringForm || !this.recurringListBody) {
+      return;
+    }
+
+    const clientSelect = this.recurringForm.querySelector('[name="clientId"]');
+    if (clientSelect) {
+      const currentValue = clientSelect.value;
+      clearChildren(clientSelect);
+      const placeholder = document.createElement('option');
+      placeholder.value = '';
+      placeholder.textContent = 'Select client';
+      clientSelect.appendChild(placeholder);
+      this.state.clients.forEach((client) => {
+        const option = document.createElement('option');
+        option.value = client.id;
+        option.textContent = `${client.businessName} (${client.name})`;
+        clientSelect.appendChild(option);
+      });
+      if (currentValue) {
+        clientSelect.value = currentValue;
+      }
+    }
+
+    const frequencySelect = this.recurringForm.querySelector('[name="frequency"]');
+    if (frequencySelect) {
+      const currentValue = frequencySelect.value;
+      clearChildren(frequencySelect);
+      const options = RecurringInvoiceManager.getFrequencyOptions();
+      options.forEach(({ value, label }) => {
+        const option = document.createElement('option');
+        option.value = value;
+        option.textContent = label;
+        frequencySelect.appendChild(option);
+      });
+      if (currentValue) {
+        frequencySelect.value = currentValue;
+      } else {
+        const preferred = options.find((option) => option.value === 'monthly');
+        if (preferred) {
+          frequencySelect.value = preferred.value;
+        }
+      }
+    }
+
+    if (!this.recurringFormInitialized) {
+      this.recurringForm.addEventListener('submit', (event) => {
+        event.preventDefault();
+        this.handleRecurringSubmit();
+      });
+      const addLineButton = this.recurringForm.querySelector('[data-action="add-line"]');
+      addLineButton?.addEventListener('click', (event) => {
+        event.preventDefault();
+        this.recurringFormEditor?.addRow();
+      });
+      const cancelButton = this.recurringForm.querySelector('[data-action="cancel"]');
+      cancelButton?.addEventListener('click', (event) => {
+        event.preventDefault();
+        this.toggleRecurringForm(false);
+      });
+      this.recurringFormInitialized = true;
+    }
+
+    clearChildren(this.recurringListBody);
+    if (!this.state.recurringSchedules.length) {
+      const emptyRow = document.createElement('tr');
+      const cell = document.createElement('td');
+      cell.colSpan = 6;
+      cell.textContent = 'No recurring schedules configured yet.';
+      emptyRow.appendChild(cell);
+      this.recurringListBody.appendChild(emptyRow);
+      return;
+    }
+
+    this.state.recurringSchedules.forEach((schedule) => {
+      const row = document.createElement('tr');
+      const clientLabel = schedule.clientBusinessName || schedule.clientName || 'Unknown client';
+      const clientMeta =
+        schedule.clientBusinessName &&
+        schedule.clientName &&
+        schedule.clientBusinessName !== schedule.clientName;
+      const actions = [
+        `<button class="btn btn--sm btn--ghost" data-action="edit" data-id="${schedule.id}">Edit</button>`,
+        `<button class="btn btn--sm btn--primary" data-action="run" data-id="${schedule.id}">Run now</button>`,
+        `<button class="btn btn--sm btn--destructive" data-action="delete" data-id="${schedule.id}">Delete</button>`
+      ].join('');
+      const lastRun = schedule.lastRun ? formatDate(schedule.lastRun) : '—';
+      const nextRun = schedule.nextRun ? formatDate(schedule.nextRun) : '—';
+      row.innerHTML = `
+        <td>
+          <div class="table-cell__primary">${schedule.name}</div>
+          ${schedule.description ? `<div class="status-meta">${schedule.description}</div>` : ''}
+        </td>
+        <td>
+          <div class="table-cell__primary">${clientLabel}</div>
+          ${clientMeta ? `<div class="status-meta">${schedule.clientName}</div>` : ''}
+        </td>
+        <td>${schedule.frequencyLabel}</td>
+        <td>${nextRun}</td>
+        <td>${lastRun}</td>
+        <td class="text-right">${actions}</td>
+      `;
+      this.recurringListBody.appendChild(row);
+    });
+
+    this.recurringListBody.querySelectorAll('[data-action="edit"]').forEach((button) => {
+      button.addEventListener('click', (event) => {
+        event.preventDefault();
+        const scheduleId = button.getAttribute('data-id');
+        const schedule = this.state.recurringSchedules.find((item) => item.id === scheduleId);
+        if (!schedule) {
+          this.showToast('Unable to locate the selected schedule.', 'error');
+          return;
+        }
+        this.toggleRecurringForm(true, schedule);
+      });
+    });
+
+    this.recurringListBody.querySelectorAll('[data-action="run"]').forEach((button) => {
+      button.addEventListener('click', (event) => {
+        event.preventDefault();
+        const scheduleId = button.getAttribute('data-id');
+        if (!scheduleId) {
+          return;
+        }
+        const outcome = RecurringInvoiceManager.runSchedule(scheduleId);
+        if (!outcome) {
+          this.showToast('Unable to run the schedule. Please try again.', 'error');
+          return;
+        }
+        this.showToast(`Invoice generated from ${outcome.schedule.name}.`, 'success');
+        this.refreshData();
+        this.renderAll();
+      });
+    });
+
+    this.recurringListBody.querySelectorAll('[data-action="delete"]').forEach((button) => {
+      button.addEventListener('click', (event) => {
+        event.preventDefault();
+        const scheduleId = button.getAttribute('data-id');
+        if (!scheduleId) {
+          return;
+        }
+        const confirmed = window.confirm('Delete this recurring schedule? This action cannot be undone.');
+        if (!confirmed) {
+          return;
+        }
+        RecurringInvoiceManager.remove(scheduleId);
+        this.refreshData();
+        this.renderAll();
+        this.showToast('Recurring schedule removed.', 'info');
+      });
+    });
+  }
+
   handleInvoiceSubmit() {
     const form = this.invoiceForm;
     const invoiceId = form.querySelector('[name="invoiceId"]').value;
@@ -884,6 +1246,80 @@ class ZantraApp {
       console.error(error);
       if (feedback) {
         feedback.textContent = error.message;
+      }
+    }
+  }
+
+  handleRecurringSubmit() {
+    if (!this.recurringForm) {
+      return;
+    }
+    const form = this.recurringForm;
+    const scheduleId = form.querySelector('[name="scheduleId"]').value.trim();
+    const name = form.querySelector('[name="name"]').value.trim();
+    const clientId = form.querySelector('[name="clientId"]').value.trim();
+    const startDate = form.querySelector('[name="startDate"]').value;
+    let nextRun = form.querySelector('[name="nextRun"]').value;
+    const frequency = form.querySelector('[name="frequency"]').value;
+    const dueDaysInput = form.querySelector('[name="dueDays"]').value;
+    const notes = form.querySelector('[name="notes"]').value;
+    const items = this.recurringFormEditor ? this.recurringFormEditor.getItems() : [];
+    const feedback = form.querySelector('[data-feedback]');
+
+    if (feedback) {
+      feedback.textContent = '';
+    }
+
+    try {
+      if (!name) {
+        throw new Error('Provide a schedule name.');
+      }
+      if (!clientId) {
+        throw new Error('Select a client for the schedule.');
+      }
+      if (!startDate) {
+        throw new Error('Choose a start date.');
+      }
+      if (!nextRun) {
+        nextRun = startDate;
+      }
+      if (!frequency) {
+        throw new Error('Select a recurrence frequency.');
+      }
+      if (!items.length) {
+        throw new Error('Add at least one line item before saving.');
+      }
+      const dueDays = Number.parseInt(dueDaysInput, 10);
+      if (!Number.isFinite(dueDays) || dueDays < 1) {
+        throw new Error('Due in (days) must be at least 1.');
+      }
+
+      const payload = {
+        name,
+        clientId,
+        startDate,
+        nextRun,
+        frequency,
+        dueDays,
+        notes,
+        lineItems: items
+      };
+
+      if (scheduleId) {
+        RecurringInvoiceManager.update(scheduleId, payload);
+        this.showToast('Recurring schedule updated.', 'success');
+      } else {
+        RecurringInvoiceManager.create(payload);
+        this.showToast('Recurring schedule created.', 'success');
+      }
+
+      this.toggleRecurringForm(false);
+      this.refreshData();
+      this.renderAll();
+    } catch (error) {
+      console.error('Failed to save recurring schedule:', error);
+      if (feedback) {
+        feedback.textContent = error.message || 'Unable to save schedule. Please try again.';
       }
     }
   }

--- a/src/managers/RecurringInvoiceManager.js
+++ b/src/managers/RecurringInvoiceManager.js
@@ -1,0 +1,354 @@
+import { DataManager } from '../data/DataManager.js';
+import { ClientManager } from './ClientManager.js';
+import { InvoiceManager } from './InvoiceManager.js';
+
+const sanitizeString = (value) => (typeof value === 'string' ? value.trim() : '');
+
+const sanitizeNumber = (value) => {
+  const numeric = Number.parseFloat(value);
+  if (Number.isNaN(numeric) || !Number.isFinite(numeric)) {
+    return 0;
+  }
+  return Math.max(0, Math.round(numeric * 100) / 100);
+};
+
+const toDateAtStartOfDay = (input) => {
+  if (!input) {
+    return null;
+  }
+  const date = input instanceof Date ? new Date(input.getTime()) : new Date(input);
+  if (Number.isNaN(date.getTime())) {
+    return null;
+  }
+  date.setHours(0, 0, 0, 0);
+  return date;
+};
+
+const toIsoDate = (input, fallback) => {
+  const date = toDateAtStartOfDay(input) || (fallback ? toDateAtStartOfDay(fallback) : null);
+  return date ? date.toISOString() : '';
+};
+
+const addDays = (date, days) => {
+  const next = new Date(date.getTime());
+  next.setDate(next.getDate() + days);
+  return next;
+};
+
+const addMonths = (date, months) => {
+  const next = new Date(date.getTime());
+  const originalDate = next.getDate();
+  next.setMonth(next.getMonth() + months);
+  if (next.getDate() < originalDate) {
+    next.setDate(0);
+  }
+  return next;
+};
+
+const FREQUENCIES = Object.freeze({
+  weekly: {
+    value: 'weekly',
+    label: 'Weekly',
+    add: (date) => addDays(date, 7)
+  },
+  fortnightly: {
+    value: 'fortnightly',
+    label: 'Fortnightly',
+    add: (date) => addDays(date, 14)
+  },
+  monthly: {
+    value: 'monthly',
+    label: 'Monthly',
+    add: (date) => addMonths(date, 1)
+  },
+  quarterly: {
+    value: 'quarterly',
+    label: 'Quarterly',
+    add: (date) => addMonths(date, 3)
+  },
+  annually: {
+    value: 'annually',
+    label: 'Annually',
+    add: (date) => addMonths(date, 12)
+  }
+});
+
+const MAX_SCHEDULE_ADVANCE = 48;
+
+export class RecurringInvoiceManager {
+  static FREQUENCIES = FREQUENCIES;
+
+  static list() {
+    return DataManager.listRecurringSchedules()
+      .map((record) => RecurringInvoiceManager.#normalize(record, { allowMissingClient: true, preserveCreatedAt: true }))
+      .sort((a, b) => {
+        const aTime = a.nextRun ? Date.parse(a.nextRun) : Number.POSITIVE_INFINITY;
+        const bTime = b.nextRun ? Date.parse(b.nextRun) : Number.POSITIVE_INFINITY;
+        if (Number.isNaN(aTime) && Number.isNaN(bTime)) {
+          return sanitizeString(a.name).localeCompare(sanitizeString(b.name));
+        }
+        if (Number.isNaN(aTime)) {
+          return 1;
+        }
+        if (Number.isNaN(bTime)) {
+          return -1;
+        }
+        return aTime - bTime;
+      });
+  }
+
+  static findById(scheduleId) {
+    const id = sanitizeString(scheduleId);
+    if (!id) {
+      return null;
+    }
+    return RecurringInvoiceManager.list().find((schedule) => schedule.id === id) || null;
+  }
+
+  static getFrequencyOptions() {
+    return Object.values(FREQUENCIES).map(({ value, label }) => ({ value, label }));
+  }
+
+  static create(input) {
+    const now = DataManager.now();
+    const normalized = RecurringInvoiceManager.#normalize(
+      {
+        ...input,
+        id: DataManager.randomUUID(),
+        createdAt: now,
+        updatedAt: now
+      },
+      { allowMissingClient: false, preserveCreatedAt: false }
+    );
+    return DataManager.saveRecurringSchedule(normalized);
+  }
+
+  static update(scheduleId, updates) {
+    const existing = RecurringInvoiceManager.findById(scheduleId);
+    if (!existing) {
+      throw new Error(`RecurringInvoiceManager.update: No schedule found for id "${scheduleId}".`);
+    }
+    const normalized = RecurringInvoiceManager.#normalize(
+      {
+        ...existing,
+        ...updates,
+        id: existing.id,
+        createdAt: existing.createdAt,
+        updatedAt: DataManager.now()
+      },
+      { allowMissingClient: false, preserveCreatedAt: true }
+    );
+    return DataManager.saveRecurringSchedule(normalized);
+  }
+
+  static remove(scheduleId) {
+    return DataManager.deleteRecurringSchedule(scheduleId);
+  }
+
+  static runSchedule(scheduleId, referenceDate = new Date()) {
+    const schedule = RecurringInvoiceManager.findById(scheduleId);
+    if (!schedule) {
+      return null;
+    }
+    const runDateIso = schedule.nextRun || toIsoDate(referenceDate, DataManager.now());
+    const runDate = toDateAtStartOfDay(runDateIso) || new Date();
+    const executionDate = toDateAtStartOfDay(referenceDate) || runDate;
+
+    if (!schedule.lineItems?.length) {
+      console.warn(`RecurringInvoiceManager.runSchedule: Schedule "${scheduleId}" has no line items.`);
+      return null;
+    }
+
+    try {
+      const dueDays = Number.isFinite(schedule.dueDays) ? schedule.dueDays : 14;
+      const dueDate = addDays(runDate, Math.max(1, dueDays));
+      const invoicePayload = {
+        clientId: schedule.clientId,
+        issueDate: runDate.toISOString(),
+        dueDate: dueDate.toISOString(),
+        notes: schedule.notes,
+        lineItems: schedule.lineItems.map((item) => ({
+          serviceId: item.serviceId,
+          description: item.description,
+          quantity: item.quantity,
+          unitPrice: item.unitPrice,
+          applyGst: item.applyGst
+        })),
+        status: 'unpaid',
+        type: 'invoice'
+      };
+
+      const createdInvoice = InvoiceManager.create(invoicePayload);
+      DataManager.saveInvoice({ ...createdInvoice, type: 'invoice' });
+
+      const updatedSchedule = RecurringInvoiceManager.#recordRun(
+        schedule,
+        runDate.toISOString(),
+        executionDate.toISOString()
+      );
+
+      return { invoice: createdInvoice, schedule: updatedSchedule };
+    } catch (error) {
+      console.error('RecurringInvoiceManager.runSchedule failed:', error);
+      return null;
+    }
+  }
+
+  static executeDueSchedules(referenceDate = new Date()) {
+    const now = toDateAtStartOfDay(referenceDate) || new Date();
+    const schedules = RecurringInvoiceManager.list();
+    const dueSchedules = schedules.filter((schedule) => {
+      if (!schedule.nextRun) {
+        return false;
+      }
+      const nextRunDate = toDateAtStartOfDay(schedule.nextRun);
+      return nextRunDate && nextRunDate.getTime() <= now.getTime();
+    });
+
+    const results = [];
+    dueSchedules.forEach((schedule) => {
+      const outcome = RecurringInvoiceManager.runSchedule(schedule.id, now);
+      if (outcome) {
+        results.push(outcome);
+      }
+    });
+    return results;
+  }
+
+  static getUpcomingSchedules(referenceDate = new Date(), windowDays = 30) {
+    const start = toDateAtStartOfDay(referenceDate) || new Date();
+    const end = addDays(start, Math.max(1, windowDays));
+    return RecurringInvoiceManager.list().filter((schedule) => {
+      if (!schedule.nextRun) {
+        return false;
+      }
+      const nextRunDate = toDateAtStartOfDay(schedule.nextRun);
+      if (!nextRunDate) {
+        return false;
+      }
+      return nextRunDate.getTime() >= start.getTime() && nextRunDate.getTime() <= end.getTime();
+    });
+  }
+
+  static #normalize(input, options = {}) {
+    if (!input || typeof input !== 'object') {
+      throw new Error('RecurringInvoiceManager: schedule payload must be an object.');
+    }
+
+    const { allowMissingClient = false, preserveCreatedAt = true } = options;
+
+    const client = RecurringInvoiceManager.#resolveClient(input, { allowMissing: allowMissingClient });
+    if (!client && !allowMissingClient) {
+      throw new Error('RecurringInvoiceManager: a valid client is required.');
+    }
+
+    const frequencyKey = RecurringInvoiceManager.#resolveFrequency(input.frequency);
+    const frequency = FREQUENCIES[frequencyKey] ?? FREQUENCIES.monthly;
+
+    const startDateIso = toIsoDate(input.startDate, DataManager.now());
+    const nextRunIso = toIsoDate(input.nextRun || startDateIso || DataManager.now(), startDateIso || DataManager.now());
+    const lastRunIso = toIsoDate(input.lastRun);
+
+    const lineItems = RecurringInvoiceManager.#normalizeLineItems(input.lineItems);
+    if (!lineItems.length) {
+      throw new Error('RecurringInvoiceManager: at least one line item is required.');
+    }
+
+    const dueDaysValue = Math.max(1, Math.min(90, Math.round(Number.parseInt(input.dueDays ?? 14, 10)) || 14));
+    const nowIso = DataManager.now();
+
+    return {
+      id: sanitizeString(input.id) || DataManager.randomUUID(),
+      name: sanitizeString(input.name) || 'Recurring invoice',
+      description: sanitizeString(input.description),
+      clientId: client?.id || sanitizeString(input.clientId),
+      clientName: client?.name || sanitizeString(input.clientName),
+      clientBusinessName: client?.businessName || sanitizeString(input.clientBusinessName),
+      frequency: frequency.value,
+      frequencyLabel: frequency.label,
+      dueDays: dueDaysValue,
+      startDate: startDateIso,
+      nextRun: nextRunIso,
+      lastRun: lastRunIso,
+      notes: sanitizeString(input.notes),
+      lineItems,
+      createdAt: preserveCreatedAt ? sanitizeString(input.createdAt) || nowIso : nowIso,
+      updatedAt: sanitizeString(input.updatedAt) || nowIso
+    };
+  }
+
+  static #resolveClient(input, { allowMissing }) {
+    const clientId = sanitizeString(input.clientId || input.client?.id);
+    if (!clientId) {
+      return null;
+    }
+    const client = ClientManager.findById(clientId);
+    if (!client && allowMissing) {
+      return {
+        id: clientId,
+        name: sanitizeString(input.clientName) || 'Unknown client',
+        businessName: sanitizeString(input.clientBusinessName)
+      };
+    }
+    return client;
+  }
+
+  static #resolveFrequency(raw) {
+    const value = sanitizeString(raw).toLowerCase();
+    if (value && FREQUENCIES[value]) {
+      return value;
+    }
+    return FREQUENCIES.monthly.value;
+  }
+
+  static #normalizeLineItems(items) {
+    if (!Array.isArray(items)) {
+      return [];
+    }
+    return items
+      .map((item) => {
+        if (!item || typeof item !== 'object') {
+          return null;
+        }
+        const description = sanitizeString(item.description);
+        const quantity = sanitizeNumber(item.quantity || 0);
+        const unitPrice = sanitizeNumber(item.unitPrice || 0);
+        if (!description || quantity <= 0) {
+          return null;
+        }
+        return {
+          id: sanitizeString(item.id) || DataManager.randomUUID(),
+          serviceId: sanitizeString(item.serviceId),
+          description,
+          quantity,
+          unitPrice,
+          applyGst: Boolean(item.applyGst)
+        };
+      })
+      .filter(Boolean);
+  }
+
+  static #recordRun(schedule, runDateIso, referenceDateIso) {
+    const runDate = toDateAtStartOfDay(runDateIso);
+    if (!runDate) {
+      return schedule;
+    }
+    const referenceDate = toDateAtStartOfDay(referenceDateIso) || runDate;
+    const frequency = FREQUENCIES[schedule.frequency] ?? FREQUENCIES.monthly;
+    let nextRunDate = frequency.add(runDate);
+    let iterations = 0;
+    while (nextRunDate.getTime() <= referenceDate.getTime() && iterations < MAX_SCHEDULE_ADVANCE) {
+      nextRunDate = frequency.add(nextRunDate);
+      iterations += 1;
+    }
+    const normalized = {
+      ...schedule,
+      lastRun: runDate.toISOString(),
+      nextRun: nextRunDate.toISOString(),
+      updatedAt: DataManager.now()
+    };
+    return DataManager.saveRecurringSchedule(normalized);
+  }
+}
+
+export default RecurringInvoiceManager;


### PR DESCRIPTION
## Summary
- add a RecurringInvoiceManager with persistence, validation, and automatic invoice generation
- extend the invoices tab with a recurring schedule form, listing table, and dashboard reminders
- update the front-end state management to load, render, and trigger recurring schedules

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68df10ae1cc48330aa8881febd8fefe9